### PR TITLE
Fixed a transcription bug in the Serial output library: it was puttin…

### DIFF
--- a/utility/PulseSensorSerialOutput.cpp
+++ b/utility/PulseSensorSerialOutput.cpp
@@ -63,8 +63,17 @@ void PulseSensorSerialOutput::output(int signal, int bpm, int ibi) {
    and the current one.
 */
 void PulseSensorSerialOutput::outputBeat(int bpm, int ibi) {
-  outputToSerial('B', bpm);
-  outputToSerial('Q', ibi);
+  switch (OutputType) {
+    case PROCESSING_VISUALIZER:
+      outputToSerial('B', bpm);
+      outputToSerial('Q', ibi);
+      break;
+    case SERIAL_PLOTTER:
+      // We already reported bpm and ibi in the per-sample report.
+      break;
+    default: // Unknown output type. Do nothing.
+      break;
+  }    
 }
 
 /*


### PR DESCRIPTION
…g out B and Q lines when in SERIAL_PLOTTER mode.