### PR TITLE
Made Serial destination configurable via pulse.setSerial() so that it…

### DIFF
--- a/examples/InterruptBeatDetector/InterruptBeatDetector.ino
+++ b/examples/InterruptBeatDetector/InterruptBeatDetector.ino
@@ -64,6 +64,7 @@ void setup() {
   pulseSensor.analogInput(PIN_INPUT);
   pulseSensor.blinkOnPulse(PIN_BLINK);
   pulseSensor.fadeOnPulse(PIN_FADE);
+  pulseSensor.setSerial(Serial);
   pulseSensor.setOutputType(OUTPUT_TYPE);
 
   // Now that everything is ready, start reading the PulseSensor signal.

--- a/examples/ProcessEverySample/ProcessEverySample.ino
+++ b/examples/ProcessEverySample/ProcessEverySample.ino
@@ -89,6 +89,7 @@ void setup() {
   pulseSensor.analogInput(PIN_INPUT);
   pulseSensor.blinkOnPulse(PIN_BLINK);
   pulseSensor.fadeOnPulse(PIN_FADE);
+  pulseSensor.setSerial(Serial);
   pulseSensor.setOutputType(OUTPUT_TYPE);
   pulseSensor.useInterrupts(USE_INTERRUPTS);
 

--- a/keywords.txt
+++ b/keywords.txt
@@ -23,6 +23,7 @@ isInsideBeat	KEYWORD2
 outputBeat	KEYWORD2
 outputSample	KEYWORD2
 sawNewSample	KEYWORD2
+setSerial	KEYWORD2
 setOutputType	KEYWORD2
 sawStartOfBeat	KEYWORD2
 useInterrupts	KEYWORD2

--- a/src/PulseSensorPlayground.cpp
+++ b/src/PulseSensorPlayground.cpp
@@ -169,6 +169,10 @@ boolean PulseSensorPlayground::isInsideBeat(int sensorIndex) {
   return Sensors[sensorIndex].isInsideBeat();
 }
 
+void PulseSensorPlayground::setSerial(Stream &output) {
+  SerialOutput.setSerial(output);
+}
+
 void PulseSensorPlayground::setOutputType(byte outputType) {
   SerialOutput.setOutputType(outputType);
 }

--- a/src/PulseSensorPlayground.h
+++ b/src/PulseSensorPlayground.h
@@ -202,12 +202,25 @@ class PulseSensorPlayground {
     boolean isInsideBeat(int sensorIndex = 0);
 
     //---------- Serial Output functions
+    
+    /*
+       By default, the Playround doesn't output serial data automatically.
+       
+       If you want to output serial pulse data, call pulse.setSerial(Serial),
+       pulse.setSerial(Serial1), or whatever Serial stream you like.
+       
+       output = the Stream to write data to. Serial, Serial1, Serial2,
+       etc., and a SoftwareSerial are valid parameters to pass.
+    */
+    void setSerial(Stream &output);
 
     /*
-       By default, the Playground outputs in SERIAL_PLOTTER format.
+       By default, Playground output is in SERIAL_PLOTTER format.
        
        If you want output in a different format, call this function once
        sometime before calling pulse.begin().
+       
+       Remember to call pulse.setSerial() if you want serial output.
 
        outputType = SERIAL_PLOTTER to output to the Arduino Serial Plotter,
        PROCESSSING_VISUALIZER to output to the Processing Sketch

--- a/src/utility/PulseSensorSerialOutput.cpp
+++ b/src/utility/PulseSensorSerialOutput.cpp
@@ -16,7 +16,12 @@
 #include "PulseSensorSerialOutput.h"
 
 PulseSensorSerialOutput::PulseSensorSerialOutput() {
+  pOutput = NULL;
   OutputType = SERIAL_PLOTTER;
+}
+
+void PulseSensorSerialOutput::setSerial(Stream &output) {
+  pOutput = &output;
 }
 
 void PulseSensorSerialOutput::setOutputType(byte outputType) {
@@ -24,14 +29,18 @@ void PulseSensorSerialOutput::setOutputType(byte outputType) {
 }
 
 void PulseSensorSerialOutput::outputSample(PulseSensor sensors[], int numSensors) {
+  if (!pOutput) {
+    return;  // no serial output object has been set.
+  }
+
   switch (OutputType) {
     case SERIAL_PLOTTER:
       if (numSensors == 1) {
-        Serial.print(sensors[0].getBeatsPerMinute());
-        Serial.print(",");
-        Serial.print(sensors[0].getInterBeatIntervalMs());
-        Serial.print(",");
-        Serial.println(sensors[0].getLatestSample());
+        pOutput->print(sensors[0].getBeatsPerMinute());
+        pOutput->print(",");
+        pOutput->print(sensors[0].getInterBeatIntervalMs());
+        pOutput->print(",");
+        pOutput->println(sensors[0].getLatestSample());
       } else {
         //TODO: support 2 or more sensors.
       }
@@ -51,6 +60,10 @@ void PulseSensorSerialOutput::outputSample(PulseSensor sensors[], int numSensors
 }
 
 void PulseSensorSerialOutput::outputBeat(PulseSensor sensors[], int numSensors) {
+  if (!pOutput) {
+    return;  // no serial output object has been set.
+  }
+
   switch (OutputType) {
     case SERIAL_PLOTTER:
       // We've already printed this info in outputSample().
@@ -70,6 +83,10 @@ void PulseSensorSerialOutput::outputBeat(PulseSensor sensors[], int numSensors) 
 }
 
 void PulseSensorSerialOutput::outputToSerial(char symbol, int data) {
-  Serial.print(symbol);
-  Serial.println(data);
+  if (!pOutput) {
+    return;  // no serial output object has been set.
+  }
+
+  pOutput->print(symbol);
+  pOutput->println(data);
 }

--- a/src/utility/PulseSensorSerialOutput.h
+++ b/src/utility/PulseSensorSerialOutput.h
@@ -35,6 +35,12 @@ class PulseSensorSerialOutput {
        Constructs a default Serial output manager.
     */
     PulseSensorSerialOutput();
+    
+    /*
+       Tells the library what Serial output to use,
+       such as Serial, Serial1, or a SoftwareSerial.
+    */
+    void setSerial(Stream &output);
 
     /*
        Sets the format (destination) of the Serial Output:
@@ -54,6 +60,9 @@ class PulseSensorSerialOutput {
     void outputBeat(PulseSensor sensors[], int numberOfSensors);
 
   private:
+    // If non-null, the output stream to print to. If null, don't print.
+    Stream *pOutput;
+    
     // The destination of data: PROCESSING_VISUALIZER or SERIAL_PLOTTER
     int OutputType;
 

--- a/src/utility/PulseSensorTimingStatistics.cpp
+++ b/src/utility/PulseSensorTimingStatistics.cpp
@@ -79,11 +79,13 @@ int PulseSensorTimingStatistics::recordSampleTime() {
    Serial prints the sample timing statistics.
 */
 void PulseSensorTimingStatistics::outputStatistics() {
+#ifdef NOTDEF //TODO temporarily disabled to compile on Gemma.
   Serial.print(MinJitterMicros);
   Serial.print(" ");
   Serial.print(getAverageOffsetMicros());
   Serial.print(" ");
   Serial.println(MaxJitterMicros);
+#endif
 }
 
 /*


### PR DESCRIPTION
… can support SoftwareSerial. Note: pulse.setSerial() is now required for a Sketch to output pulse data via the Playground.