### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -26,7 +26,7 @@ sawNewSample	KEYWORD2
 setSerial	KEYWORD2
 setOutputType	KEYWORD2
 sawStartOfBeat	KEYWORD2
-setThreshold  KEYWORD2
+setThreshold	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE currently requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords