### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -27,10 +27,10 @@ setSerial	KEYWORD2
 setOutputType	KEYWORD2
 sawStartOfBeat	KEYWORD2
 setThreshold	KEYWORD2
-getLastBeatTime KEYWORD2
-outputToSerial  KEYWORD2
-getPulseAmplitude KEYWORD2
-getLastBeatTime KEYWORD2
+getLastBeatTime	KEYWORD2
+outputToSerial	KEYWORD2
+getPulseAmplitude	KEYWORD2
+getLastBeatTime	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE currently requires the use of a single true tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords