### PR TITLE
Added support for more STM32 Boards

### DIFF
--- a/examples/PulseSensor_BPM/PulseSensor_BPM.ino
+++ b/examples/PulseSensor_BPM/PulseSensor_BPM.ino
@@ -42,18 +42,18 @@ const int OUTPUT_TYPE = SERIAL_PLOTTER;
 
 /*
    Pinout:
-     PIN_INPUT = Analog Input. Connected to the pulse sensor
+     PULSE_INPUT = Analog Input. Connected to the pulse sensor
       purple (signal) wire.
-     PIN_BLINK = digital Output. Connected to an LED (and 220 ohm resistor)
+     PULSE_BLINK = digital Output. Connected to an LED (and 220 ohm resistor)
       that will flash on each detected pulse.
-     PIN_FADE = digital Output. PWM pin onnected to an LED (and resistor)
+     PULSE_FADE = digital Output. PWM pin onnected to an LED (and resistor)
       that will smoothly fade with each pulse.
-      NOTE: PIN_FADE must be a pin that supports PWM. Do not use
+      NOTE: PULSE_FADE must be a pin that supports PWM. Do not use
       pin 9 or 10, because those pins' PWM interferes with the sample timer.
 */
-const int PIN_INPUT = A0;
-const int PIN_BLINK = 13;    // Pin 13 is the on-board LED
-const int PIN_FADE = 5;
+const int PULSE_INPUT = A0;
+const int PULSE_BLINK = 13;    // Pin 13 is the on-board LED
+const int PULSE_FADE = 5;
 const int THRESHOLD = 550;   // Adjust this number to avoid noise when idle
 
 /*
@@ -75,9 +75,9 @@ void setup() {
 
   // Configure the PulseSensor manager.
 
-  pulseSensor.analogInput(PIN_INPUT);
-  pulseSensor.blinkOnPulse(PIN_BLINK);
-  pulseSensor.fadeOnPulse(PIN_FADE);
+  pulseSensor.analogInput(PULSE_INPUT);
+  pulseSensor.blinkOnPulse(PULSE_BLINK);
+  pulseSensor.fadeOnPulse(PULSE_FADE);
 
   pulseSensor.setSerial(Serial);
   pulseSensor.setOutputType(OUTPUT_TYPE);
@@ -95,9 +95,9 @@ void setup() {
     */
     for(;;) {
       // Flash the led to show things didn't work.
-      digitalWrite(PIN_BLINK, LOW);
+      digitalWrite(PULSE_BLINK, LOW);
       delay(50);
-      digitalWrite(PIN_BLINK, HIGH);
+      digitalWrite(PULSE_BLINK, HIGH);
       delay(50);
     }
   }

--- a/examples/PulseSensor_BPM_Alternative/PulseSensor_BPM_Alternative.ino
+++ b/examples/PulseSensor_BPM_Alternative/PulseSensor_BPM_Alternative.ino
@@ -54,19 +54,19 @@ const int OUTPUT_TYPE = SERIAL_PLOTTER;
 
 /*
    Pinout:
-     PIN_INPUT = Analog Input. Connected to the pulse sensor
+     PULSE_INPUT = Analog Input. Connected to the pulse sensor
       purple (signal) wire.
-     PIN_BLINK = digital Output. Connected to an LED (and 220 ohm resistor)
+     PULSE_BLINK = digital Output. Connected to an LED (and 220 ohm resistor)
       that will flash on each detected pulse.
-     PIN_FADE = digital Output. PWM pin onnected to an LED (and resistor)
+     PULSE_FADE = digital Output. PWM pin onnected to an LED (and resistor)
       that will smoothly fade with each pulse.
-      NOTE: PIN_FADE must be a pin that supports PWM.
-       If USE_INTERRUPTS is true, Do not use pin 9 or 10 for PIN_FADE,
+      NOTE: PULSE_FADE must be a pin that supports PWM.
+       If USE_INTERRUPTS is true, Do not use pin 9 or 10 for PULSE_FADE,
        because those pins' PWM interferes with the sample timer.
 */
-const int PIN_INPUT = A0;
-const int PIN_BLINK = 13;    // Pin 13 is the on-board LED
-const int PIN_FADE = 5;
+const int PULSE_INPUT = A0;
+const int PULSE_BLINK = 13;    // Pin 13 is the on-board LED
+const int PULSE_FADE = 5;
 const int THRESHOLD = 550;   // Adjust this number to avoid noise when idle
 
 /*
@@ -98,9 +98,9 @@ void setup() {
   Serial.begin(115200);
 
   // Configure the PulseSensor manager.
-  pulseSensor.analogInput(PIN_INPUT);
-  pulseSensor.blinkOnPulse(PIN_BLINK);
-  pulseSensor.fadeOnPulse(PIN_FADE);
+  pulseSensor.analogInput(PULSE_INPUT);
+  pulseSensor.blinkOnPulse(PULSE_BLINK);
+  pulseSensor.fadeOnPulse(PULSE_FADE);
 
   pulseSensor.setSerial(Serial);
   pulseSensor.setOutputType(OUTPUT_TYPE);
@@ -120,9 +120,9 @@ void setup() {
     */
     for(;;) {
       // Flash the led to show things didn't work.
-      digitalWrite(PIN_BLINK, LOW);
+      digitalWrite(PULSE_BLINK, LOW);
       delay(50);
-      digitalWrite(PIN_BLINK, HIGH);
+      digitalWrite(PULSE_BLINK, HIGH);
       delay(50);
     }
   }

--- a/examples/PulseSensor_PTT/PulseSensor_PTT.ino
+++ b/examples/PulseSensor_PTT/PulseSensor_PTT.ino
@@ -59,29 +59,29 @@ const int OUTPUT_TYPE = PROCESSING_VISUALIZER;
 const int PULSE_SENSOR_COUNT = 2;
 
 /*
-     PIN_POWERx = the output pin that the red (power) pin of
+     PULSE_POWERx = the output pin that the red (power) pin of
       the first PulseSensor will be connected to. PulseSensor only
       draws about 4mA, so almost any micro can power it from a GPIO.
       If you don't want to use pins to power the PulseSensors, you can remove
-      the code dealing with PIN_POWER0 and PIN_POWER1.
-     PIN_INPUTx = Analog Input. Connected to the pulse sensor
+      the code dealing with PULSE_POWER0 and PULSE_POWER1.
+     PULSE_INPUTx = Analog Input. Connected to the pulse sensor
       purple (signal) wire.
-     PIN_BLINKx = digital Output. Connected to an LED (must have at least
+     PULSE_BLINKx = digital Output. Connected to an LED (must have at least
       470 ohm resistor) that will flash on each detected pulse.
-     PIN_FADEx = digital Output. PWM pin onnected to an LED (must have
+     PULSE_FADEx = digital Output. PWM pin onnected to an LED (must have
       at least 470 ohm resistor) that will smoothly fade with each pulse.
 
-     NOTE: PIN_FADEx must be pins that support PWM.
-       If USE_INTERRUPTS is true, Do not use pin 9 or 10 for PIN_FADEx
+     NOTE: PULSE_FADEx must be pins that support PWM.
+       If USE_INTERRUPTS is true, Do not use pin 9 or 10 for PULSE_FADEx
        because those pins' PWM interferes with the sample timer.
 */
-const int PIN_INPUT0 = A0;
-const int PIN_BLINK0 = 13;    // Pin 13 is the on-board LED
-const int PIN_FADE0 = 5;
+const int PULSE_INPUT0 = A0;
+const int PULSE_BLINK0 = 13;    // Pin 13 is the on-board LED
+const int PULSE_FADE0 = 5;
 
-const int PIN_INPUT1 = A1;
-const int PIN_BLINK1 = 12;
-const int PIN_FADE1 = 11;
+const int PULSE_INPUT1 = A1;
+const int PULSE_BLINK1 = 12;
+const int PULSE_FADE1 = 11;
 
 const int THRESHOLD = 550;   // Adjust this number to avoid noise when idle
 
@@ -117,13 +117,13 @@ void setup() {
      we're configuring.
   */
 
-  pulseSensor.analogInput(PIN_INPUT0, 0);
-  pulseSensor.blinkOnPulse(PIN_BLINK0, 0);
-  pulseSensor.fadeOnPulse(PIN_FADE0, 0);
+  pulseSensor.analogInput(PULSE_INPUT0, 0);
+  pulseSensor.blinkOnPulse(PULSE_BLINK0, 0);
+  pulseSensor.fadeOnPulse(PULSE_FADE0, 0);
 
-  pulseSensor.analogInput(PIN_INPUT1, 1);
-  pulseSensor.blinkOnPulse(PIN_BLINK1, 1);
-  pulseSensor.fadeOnPulse(PIN_FADE1, 1);
+  pulseSensor.analogInput(PULSE_INPUT1, 1);
+  pulseSensor.blinkOnPulse(PULSE_BLINK1, 1);
+  pulseSensor.fadeOnPulse(PULSE_FADE1, 1);
 
   pulseSensor.setSerial(Serial);
   pulseSensor.setOutputType(OUTPUT_TYPE);
@@ -141,9 +141,9 @@ void setup() {
     */
     for (;;) {
       // Flash the led to show things didn't work.
-      digitalWrite(PIN_BLINK0, LOW);
+      digitalWrite(PULSE_BLINK0, LOW);
       delay(50);
-      digitalWrite(PIN_BLINK0, HIGH);
+      digitalWrite(PULSE_BLINK0, HIGH);
       delay(50);
     }
   }

--- a/examples/PulseSensor_Servo/PulseSensor_Servo.ino
+++ b/examples/PulseSensor_Servo/PulseSensor_Servo.ino
@@ -48,18 +48,18 @@ const int OUTPUT_TYPE = SERIAL_PLOTTER;
 
 /*
    Pinout:
-     PIN_INPUT = Analog Input. Connected to the pulse sensor
+     PULSE_INPUT = Analog Input. Connected to the pulse sensor
       purple (signal) wire.
-     PIN_BLINK = digital Output. Connected to an LED (and 220 ohm resistor)
+     PULSE_BLINK = digital Output. Connected to an LED (and 220 ohm resistor)
       that will flash on each detected pulse.
-     PIN_FADE = digital Output. PWM pin onnected to an LED (and resistor)
+     PULSE_FADE = digital Output. PWM pin onnected to an LED (and resistor)
       that will smoothly fade with each pulse.
-      NOTE: PIN_FADE must be a pin that supports PWM. Do not use
+      NOTE: PULSE_FADE must be a pin that supports PWM. Do not use
       pin 9 or 10, because those pins' PWM interferes with the sample timer.
 */
-const int PIN_INPUT = A0;
-const int PIN_BLINK = 13;    // Pin 13 is the on-board LED
-const int PIN_FADE = 5;
+const int PULSE_INPUT = A0;
+const int PULSE_BLINK = 13;    // Pin 13 is the on-board LED
+const int PULSE_FADE = 5;
 const int THRESHOLD = 550;   // Adjust this number to avoid noise when idle
 
 /*
@@ -85,15 +85,15 @@ void setup() {
      not work properly.
   */
   Serial.begin(115200);
-  // set up the heart servo on SERVO_PIN
+  // set up the heart servo on SERVO_PULSE
   // set servo position to pos (90 degrees, mid position)
   heart.attach(SERVO_PIN);
   heart.write(pos);
 
   // Configure the PulseSensor manager.
-  pulseSensor.analogInput(PIN_INPUT);
-  pulseSensor.blinkOnPulse(PIN_BLINK);
-  pulseSensor.fadeOnPulse(PIN_FADE);
+  pulseSensor.analogInput(PULSE_INPUT);
+  pulseSensor.blinkOnPulse(PULSE_BLINK);
+  pulseSensor.fadeOnPulse(PULSE_FADE);
 
   pulseSensor.setSerial(Serial);
   pulseSensor.setOutputType(OUTPUT_TYPE);
@@ -111,9 +111,9 @@ void setup() {
     */
     for(;;) {
       // Flash the led to show things didn't work.
-      digitalWrite(PIN_BLINK, LOW);
+      digitalWrite(PULSE_BLINK, LOW);
       delay(50);
-      digitalWrite(PIN_BLINK, HIGH);
+      digitalWrite(PULSE_BLINK, HIGH);
       delay(50);
     }
   }

--- a/examples/PulseSensor_Speaker/PulseSensor_Speaker.ino
+++ b/examples/PulseSensor_Speaker/PulseSensor_Speaker.ino
@@ -45,18 +45,18 @@ const int OUTPUT_TYPE = SERIAL_PLOTTER;
 
 /*
    Pinout:
-     PIN_INPUT = Analog Input. Connected to the pulse sensor
+     PULSE_INPUT = Analog Input. Connected to the pulse sensor
       purple (signal) wire.
-     PIN_BLINK = digital Output. Connected to an LED (and 220 ohm resistor)
+     PULSE_BLINK = digital Output. Connected to an LED (and 220 ohm resistor)
       that will flash on each detected pulse.
-     PIN_FADE = digital Output. PWM pin onnected to an LED (and resistor)
+     PULSE_FADE = digital Output. PWM pin onnected to an LED (and resistor)
       that will smoothly fade with each pulse.
-      NOTE: PIN_FADE must be a pin that supports PWM. Do not use
+      NOTE: PULSE_FADE must be a pin that supports PWM. Do not use
       pin 9 or 10, because those pins' PWM interferes with the sample timer.
 */
-const int PIN_INPUT = A0;
-const int PIN_BLINK = 13;    // Pin 13 is the on-board LED
-const int PIN_FADE = 5;
+const int PULSE_INPUT = A0;
+const int PULSE_BLINK = 13;    // Pin 13 is the on-board LED
+const int PULSE_FADE = 5;
 const int THRESHOLD = 550;   // Adjust this number to avoid noise when idle
 
 /*
@@ -90,9 +90,9 @@ void setup() {
 
   // Configure the PulseSensor manager.
 
-  pulseSensor.analogInput(PIN_INPUT);
-  pulseSensor.blinkOnPulse(PIN_BLINK);
-  pulseSensor.fadeOnPulse(PIN_FADE);
+  pulseSensor.analogInput(PULSE_INPUT);
+  pulseSensor.blinkOnPulse(PULSE_BLINK);
+  pulseSensor.fadeOnPulse(PULSE_FADE);
 
   pulseSensor.setSerial(Serial);
   pulseSensor.setOutputType(OUTPUT_TYPE);
@@ -110,9 +110,9 @@ void setup() {
     */
     for(;;) {
       // Flash the led to show things didn't work.
-      digitalWrite(PIN_BLINK, LOW);
+      digitalWrite(PULSE_BLINK, LOW);
       delay(50);
-      digitalWrite(PIN_BLINK, HIGH);
+      digitalWrite(PULSE_BLINK, HIGH);
       delay(50);
     }
   }

--- a/examples/SoftwareSerialDemo/SoftwareSerialDemo.ino
+++ b/examples/SoftwareSerialDemo/SoftwareSerialDemo.ino
@@ -46,9 +46,9 @@ const int OUTPUT_TYPE = SERIAL_PLOTTER;
 const int PIN_RX = 7;
 const int PIN_TX = 8;
 
-const int PIN_INPUT = A0;
-const int PIN_BLINK = 13;    // Pin 13 is the on-board LED
-const int PIN_FADE = 5;      // Must be a PWM pin other than 9 or 10.
+const int PULSE_INPUT = A0;
+const int PULSE_BLINK = 13;    // Pin 13 is the on-board LED
+const int PULSE_FADE = 5;      // Must be a PWM pin other than 9 or 10.
 const int THRESHOLD = 550;   // Adjust this number to avoid noise when idle
 
 /*
@@ -64,9 +64,9 @@ void setup() {
 
   // Configure the PulseSensor manager.
 
-  pulseSensor.analogInput(PIN_INPUT);
-  pulseSensor.blinkOnPulse(PIN_BLINK);
-  pulseSensor.fadeOnPulse(PIN_FADE);
+  pulseSensor.analogInput(PULSE_INPUT);
+  pulseSensor.blinkOnPulse(PULSE_BLINK);
+  pulseSensor.fadeOnPulse(PULSE_FADE);
 
   pulseSensor.setSerial(ourSerial);
   pulseSensor.setOutputType(OUTPUT_TYPE);
@@ -82,9 +82,9 @@ void setup() {
      */
     for(;;) {
       // Flash the led to show things didn't work.
-      digitalWrite(PIN_BLINK, LOW);
+      digitalWrite(PULSE_BLINK, LOW);
       delay(50);
-      digitalWrite(PIN_BLINK, HIGH);
+      digitalWrite(PULSE_BLINK, HIGH);
       delay(50);
     }
   }

--- a/examples/TwoPulseSensors_On_OneArduino/TwoPulseSensors_On_OneArduino.ino
+++ b/examples/TwoPulseSensors_On_OneArduino/TwoPulseSensors_On_OneArduino.ino
@@ -57,29 +57,29 @@ const int OUTPUT_TYPE = SERIAL_PLOTTER;
 const int PULSE_SENSOR_COUNT = 2;
 
 /*
-     PIN_POWERx = the output pin that the red (power) pin of
+     PULSE_POWERx = the output pin that the red (power) pin of
       the first PulseSensor will be connected to. PulseSensor only
       draws about 4mA, so almost any micro can power it from a GPIO.
       If you don't want to use pins to power the PulseSensors, you can remove
-      the code dealing with PIN_POWER0 and PIN_POWER1.
-     PIN_INPUTx = Analog Input. Connected to the pulse sensor
+      the code dealing with PULSE_POWER0 and PULSE_POWER1.
+     PULSE_INPUTx = Analog Input. Connected to the pulse sensor
       purple (signal) wire.
-     PIN_BLINKx = digital Output. Connected to an LED (must have at least
+     PULSE_BLINKx = digital Output. Connected to an LED (must have at least
       470 ohm resistor) that will flash on each detected pulse.
-     PIN_FADEx = digital Output. PWM pin onnected to an LED (must have
+     PULSE_FADEx = digital Output. PWM pin onnected to an LED (must have
       at least 470 ohm resistor) that will smoothly fade with each pulse.
 
-     NOTE: PIN_FADEx must be pins that support PWM.
-       If USE_INTERRUPTS is true, Do not use pin 9 or 10 for PIN_FADEx
+     NOTE: PULSE_FADEx must be pins that support PWM.
+       If USE_INTERRUPTS is true, Do not use pin 9 or 10 for PULSE_FADEx
        because those pins' PWM interferes with the sample timer.
 */
-const int PIN_INPUT0 = A0;
-const int PIN_BLINK0 = 13;    // Pin 13 is the on-board LED
-const int PIN_FADE0 = 5;
+const int PULSE_INPUT0 = A0;
+const int PULSE_BLINK0 = 13;    // Pin 13 is the on-board LED
+const int PULSE_FADE0 = 5;
 
-const int PIN_INPUT1 = A1;
-const int PIN_BLINK1 = 12;
-const int PIN_FADE1 = 11;
+const int PULSE_INPUT1 = A1;
+const int PULSE_BLINK1 = 12;
+const int PULSE_FADE1 = 11;
 
 const int THRESHOLD = 550;   // Adjust this number to avoid noise when idle
 
@@ -108,13 +108,13 @@ void setup() {
      we're configuring.
   */
 
-  pulseSensor.analogInput(PIN_INPUT0, 0);
-  pulseSensor.blinkOnPulse(PIN_BLINK0, 0);
-  pulseSensor.fadeOnPulse(PIN_FADE0, 0);
+  pulseSensor.analogInput(PULSE_INPUT0, 0);
+  pulseSensor.blinkOnPulse(PULSE_BLINK0, 0);
+  pulseSensor.fadeOnPulse(PULSE_FADE0, 0);
 
-  pulseSensor.analogInput(PIN_INPUT1, 1);
-  pulseSensor.blinkOnPulse(PIN_BLINK1, 1);
-  pulseSensor.fadeOnPulse(PIN_FADE1, 1);
+  pulseSensor.analogInput(PULSE_INPUT1, 1);
+  pulseSensor.blinkOnPulse(PULSE_BLINK1, 1);
+  pulseSensor.fadeOnPulse(PULSE_FADE1, 1);
 
   pulseSensor.setSerial(Serial);
   pulseSensor.setOutputType(OUTPUT_TYPE);
@@ -132,9 +132,9 @@ void setup() {
     */
     for (;;) {
       // Flash the led to show things didn't work.
-      digitalWrite(PIN_BLINK0, LOW);
+      digitalWrite(PULSE_BLINK0, LOW);
       delay(50);
-      digitalWrite(PIN_BLINK0, HIGH);
+      digitalWrite(PULSE_BLINK0, HIGH);
       delay(50);
     }
   }

--- a/examples/TwoPulseSensors_On_OneArduino_Alternative/TwoPulseSensors_On_OneArduino_Alternative.ino
+++ b/examples/TwoPulseSensors_On_OneArduino_Alternative/TwoPulseSensors_On_OneArduino_Alternative.ino
@@ -57,29 +57,29 @@ const int OUTPUT_TYPE = SERIAL_PLOTTER;
 const int PULSE_SENSOR_COUNT = 2;
 
 /*
-     PIN_POWERx = the output pin that the red (power) pin of
+     PULSE_POWERx = the output pin that the red (power) pin of
       the first PulseSensor will be connected to. PulseSensor only
       draws about 4mA, so almost any micro can power it from a GPIO.
       If you don't want to use pins to power the PulseSensors, you can remove
-      the code dealing with PIN_POWER0 and PIN_POWER1.
-     PIN_INPUTx = Analog Input. Connected to the pulse sensor
+      the code dealing with PULSE_POWER0 and PULSE_POWER1.
+     PULSE_INPUTx = Analog Input. Connected to the pulse sensor
       purple (signal) wire.
-     PIN_BLINKx = digital Output. Connected to an LED (must have at least
+     PULSE_BLINKx = digital Output. Connected to an LED (must have at least
       470 ohm resistor) that will flash on each detected pulse.
-     PIN_FADEx = digital Output. PWM pin onnected to an LED (must have
+     PULSE_FADEx = digital Output. PWM pin onnected to an LED (must have
       at least 470 ohm resistor) that will smoothly fade with each pulse.
 
-     NOTE: PIN_FADEx must be pins that support PWM.
-       If USE_INTERRUPTS is true, Do not use pin 9 or 10 for PIN_FADEx
+     NOTE: PULSE_FADEx must be pins that support PWM.
+       If USE_INTERRUPTS is true, Do not use pin 9 or 10 for PULSE_FADEx
        because those pins' PWM interferes with the sample timer.
 */
-const int PIN_INPUT0 = A0;
-const int PIN_BLINK0 = 13;    // Pin 13 is the on-board LED
-const int PIN_FADE0 = 5;
+const int PULSE_INPUT0 = A0;
+const int PULSE_BLINK0 = 13;    // Pin 13 is the on-board LED
+const int PULSE_FADE0 = 5;
 
-const int PIN_INPUT1 = A1;
-const int PIN_BLINK1 = 12;
-const int PIN_FADE1 = 11;
+const int PULSE_INPUT1 = A1;
+const int PULSE_BLINK1 = 12;
+const int PULSE_FADE1 = 11;
 
 const int THRESHOLD = 550;   // Adjust this number to avoid noise when idle
 
@@ -119,13 +119,13 @@ void setup() {
      we're configuring.
   */
 
-  pulseSensor.analogInput(PIN_INPUT0, 0);
-  pulseSensor.blinkOnPulse(PIN_BLINK0, 0);
-  pulseSensor.fadeOnPulse(PIN_FADE0, 0);
+  pulseSensor.analogInput(PULSE_INPUT0, 0);
+  pulseSensor.blinkOnPulse(PULSE_BLINK0, 0);
+  pulseSensor.fadeOnPulse(PULSE_FADE0, 0);
 
-  pulseSensor.analogInput(PIN_INPUT1, 1);
-  pulseSensor.blinkOnPulse(PIN_BLINK1, 1);
-  pulseSensor.fadeOnPulse(PIN_FADE1, 1);
+  pulseSensor.analogInput(PULSE_INPUT1, 1);
+  pulseSensor.blinkOnPulse(PULSE_BLINK1, 1);
+  pulseSensor.fadeOnPulse(PULSE_FADE1, 1);
 
   pulseSensor.setSerial(Serial);
   pulseSensor.setOutputType(OUTPUT_TYPE);
@@ -145,9 +145,9 @@ void setup() {
     */
     for (;;) {
       // Flash the led to show things didn't work.
-      digitalWrite(PIN_BLINK0, LOW);
+      digitalWrite(PULSE_BLINK0, LOW);
       delay(50);
-      digitalWrite(PIN_BLINK0, HIGH);
+      digitalWrite(PULSE_BLINK0, HIGH);
       delay(50);
     }
   }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=PulseSensor Playground
-version=1.4.8
+version=1.4.9
 author=Joel Murphy, Yury Gitman, Brad Needham
 maintainer=Joel Murphy, Yury Gitman
 sentence=Support at PulseSensor.com

--- a/src/utility/Interrupts.h
+++ b/src/utility/Interrupts.h
@@ -62,8 +62,9 @@
 //
 // Macros to link to interrupt disable/enable only if they exist
 // The name is long to avoid collisions with Sketch and Library symbols.
-#if defined(__arc__)||(ARDUINO_SAMD_MKR1000)||(ARDUINO_SAMD_MKRZERO)||(ARDUINO_SAMD_ZERO)||(ARDUINO_STM32_STAR_OTTO)
-  // Arduino 101 doesn't have cli() and sei().
+#if defined(__arc__)||(ARDUINO_SAMD_MKR1000)||(ARDUINO_SAMD_MKRZERO)||(ARDUINO_SAMD_ZERO)\
+||(ARDUINO_ARCH_STM32)||(ARDUINO_STM32_STAR_OTTO)
+
 #define DISABLE_PULSE_SENSOR_INTERRUPTS
 #define ENABLE_PULSE_SENSOR_INTERRUPTS
 #else


### PR DESCRIPTION
Supports Nucleo family, Discovery, Maple, and other STM32 boards.
Had to change the naming convention of our pin constants in the examples
PIN_INPUT is already defined in the STM32 core libraries
Changed all mention of PIN with PULSE
PULSE_INPUT
PULSE_BLINK
PULSE_FADE