### PR TITLE
Added Support for STM32 boards with Nucleo example

### DIFF
--- a/examples/PulseSensor_Nucleo/PulseSensor_Nucleo.ino
+++ b/examples/PulseSensor_Nucleo/PulseSensor_Nucleo.ino
@@ -15,7 +15,7 @@
       Serial Interface: Enable first third (USART to 3 if available)
       USB Interace: None
       Upload Method: STlink
-      Optimize: Smalles (-Os) defalut
+      Optimize: Smallest (-Os) defalut
 
   This sketch uses Serial1 to communicate with your computer.
   Attach an FTDI or other USB > Serial breakout to the pins

--- a/examples/PulseSensor_Nucleo/PulseSensor_Nucleo.ino
+++ b/examples/PulseSensor_Nucleo/PulseSensor_Nucleo.ino
@@ -15,7 +15,7 @@
       Serial Interface: Enable first third (USART to 3 if available)
       USB Interace: None
       Upload Method: STlink
-      Optimize: Smallest (-Os) defalut
+      Optimize: Smallest (-Os defalut)
 
   This sketch uses Serial1 to communicate with your computer.
   Attach an FTDI or other USB > Serial breakout to the pins

--- a/examples/PulseSensor_Nucleo/PulseSensor_Nucleo.ino
+++ b/examples/PulseSensor_Nucleo/PulseSensor_Nucleo.ino
@@ -1,0 +1,191 @@
+/*
+   Sketch to handle each sample read from a PulseSensor.
+   Typically used when you don't want to use interrupts
+   to read PulseSensor voltages.
+
+   Here is a link to the tutorial that discusses this code
+   >> Comming Soon! <<
+
+   This example targets the Nucleo 64 F401RE
+   If you are using a different Nucleo board, you may have to change some of the
+   board parameters. Here are the drop-down selections that I used.
+
+      Board: Nucleo-64
+      Board Part Number: Nucleo F401RE
+      Serial Interface: Enable first third (USART to 3 if available)
+      USB Interace: None
+      Upload Method: STlink
+      Optimize: Smalles (-Os) defalut
+
+  This sketch uses Serial1 to communicate with your computer.
+  Attach an FTDI or other USB > Serial breakout to the pins
+
+      tx: D8 (Arduino Pin)
+      rx: D2 (Arduino Pin)
+
+   Copyright World Famous Electronics LLC - see LICENSE
+   Contributors:
+     Joel Murphy, https://pulsesensor.com
+     Yury Gitman, https://pulsesensor.com
+     Bradford Needham, @bneedhamia, https://bluepapertech.com
+
+   Licensed under the MIT License, a copy of which
+   should have been included with this software.
+
+   This software is not intended for medical use.
+*/
+
+/*
+   Every Sketch that uses the PulseSensor Playground must
+   define USE_ARDUINO_INTERRUPTS before including PulseSensorPlayground.h.
+   Here, #define USE_ARDUINO_INTERRUPTS false tells the library to
+   not use interrupts to read data from the PulseSensor.
+
+   If you want to use interrupts, simply change the line below
+   to read:
+     #define USE_ARDUINO_INTERRUPTS true
+
+   Set US_PS_INTERRUPTS to false if either
+   1) Your Arduino platform's interrupts aren't yet supported
+   by PulseSensor Playground, or
+   2) You don't wish to use interrupts because of the side effects.
+
+   NOTE: if US_PS_INTERRUPTS is false, your Sketch must
+   call pulse.sawNewSample() at least once every 2 milliseconds
+   to accurately read the PulseSensor signal.
+*/
+#define USE_ARDUINO_INTERRUPTS false
+#include <PulseSensorPlayground.h>
+
+/*
+   The format of our output.
+
+   Set this to PROCESSING_VISUALIZER if you're going to run
+    the Processing Visualizer Sketch.
+    See https://github.com/WorldFamousElectronics/PulseSensor_Amped_Processing_Visualizer
+
+   Set this to SERIAL_PLOTTER if you're going to run
+    the Arduino IDE's Serial Plotter.
+*/
+const int OUTPUT_TYPE = SERIAL_PLOTTER;
+
+/*
+   Pinout:
+     PULSE_INPUT = Analog Input. Connected to the pulse sensor
+      purple (signal) wire.
+     PULSE_BLINK = digital Output. Connected to an LED (and 220 ohm resistor)
+      that will flash on each detected pulse.
+     PULSE_FADE = digital Output. PWM pin onnected to an LED (and resistor)
+      that will smoothly fade with each pulse.
+      NOTE: PULSE_FADE must be a pin that supports PWM.
+       If USE_INTERRUPTS is true, Do not use pin 9 or 10 for PULSE_FADE,
+       because those pins' PWM interferes with the sample timer.
+*/
+const int PULSE_INPUT = A0;
+const int PULSE_BLINK = 13;    // Pin 13 is the on-board LED
+const int PULSE_FADE = 5;
+const int THRESHOLD = 550;   // Adjust this number to avoid noise when idle
+
+/*
+   samplesUntilReport = the number of samples remaining to read
+   until we want to report a sample over the serial connection.
+
+   We want to report a sample value over the serial port
+   only once every 20 milliseconds (10 samples) to avoid
+   doing Serial output faster than the Arduino can send.
+*/
+byte samplesUntilReport;
+const byte SAMPLES_PER_SERIAL_SAMPLE = 10;
+
+/*
+   All the PulseSensor Playground functions.
+*/
+PulseSensorPlayground pulseSensor;
+
+void setup() {
+  /*
+     Use 115200 baud because that's what the Processing Sketch expects to read,
+     and because that speed provides about 11 bytes per millisecond.
+
+     If we used a slower baud rate, we'd likely write bytes faster than
+     they can be transmitted, which would mess up the timing
+     of readSensor() calls, which would make the pulse measurement
+     not work properly.
+  */
+  Serial1.begin(115200);
+
+  // Configure the PulseSensor manager.
+  pulseSensor.analogInput(PULSE_INPUT);
+  pulseSensor.blinkOnPulse(PULSE_BLINK);
+  pulseSensor.fadeOnPulse(PULSE_FADE);
+
+  pulseSensor.setSerial(Serial1);
+  pulseSensor.setOutputType(OUTPUT_TYPE);
+  pulseSensor.setThreshold(THRESHOLD);
+
+  // Skip the first SAMPLES_PER_SERIAL_SAMPLE in the loop().
+  samplesUntilReport = SAMPLES_PER_SERIAL_SAMPLE;
+
+  // Now that everything is ready, start reading the PulseSensor signal.
+  if (!pulseSensor.begin()) {
+    /*
+       PulseSensor initialization failed,
+       likely because our Arduino platform interrupts
+       aren't supported yet.
+
+       If your Sketch hangs here, try changing USE_PS_INTERRUPT to false.
+    */
+    for(;;) {
+      // Flash the led to show things didn't work.
+      digitalWrite(PULSE_BLINK, LOW);
+      delay(50);
+      digitalWrite(PULSE_BLINK, HIGH);
+      delay(50);
+    }
+  }
+}
+
+void loop() {
+
+  /*
+     See if a sample is ready from the PulseSensor.
+
+     If USE_INTERRUPTS is true, the PulseSensor Playground
+     will automatically read and process samples from
+     the PulseSensor.
+
+     If USE_INTERRUPTS is false, this call to sawNewSample()
+     will, if enough time has passed, read and process a
+     sample (analog voltage) from the PulseSensor.
+  */
+  if (pulseSensor.sawNewSample()) {
+    /*
+       Every so often, send the latest Sample.
+       We don't print every sample, because our baud rate
+       won't support that much I/O.
+    */
+    if (--samplesUntilReport == (byte) 0) {
+      samplesUntilReport = SAMPLES_PER_SERIAL_SAMPLE;
+
+      pulseSensor.outputSample();
+
+      /*
+         At about the beginning of every heartbeat,
+         report the heart rate and inter-beat-interval.
+      */
+      if (pulseSensor.sawStartOfBeat()) {
+        pulseSensor.outputBeat();
+      }
+    }
+
+    /*******
+      Here is a good place to add code that could take up
+      to a millisecond or so to run.
+    *******/
+  }
+
+  /******
+     Don't add code here, because it could slow the sampling
+     from the PulseSensor.
+  ******/
+}

--- a/src/PulseSensorPlayground.cpp
+++ b/src/PulseSensorPlayground.cpp
@@ -210,14 +210,14 @@ void PulseSensorPlayground::outputToSerial(char s, int d) {
 
 int PulseSensorPlayground::getPulseAmplitude(int sensorIndex) {
   if (sensorIndex != constrain(sensorIndex, 0, SensorCount)) {
-    return; // out of range.
+    return -1; // out of range.
   }
   return Sensors[sensorIndex].getPulseAmplitude();
 }
 
 unsigned long PulseSensorPlayground::getLastBeatTime(int sensorIndex) {
   if (sensorIndex != constrain(sensorIndex, 0, SensorCount)) {
-    return; // out of range.
+    return -1; // out of range.
   }
   return Sensors[sensorIndex].getLastBeatTime();
 }


### PR DESCRIPTION
PulseSensor Playground now works with Star OTTO, Nucleo, and other STM32 boards. There is an example that targets the Nucleo 64 F401RE.

Changed the pin constant names in order to be compatible with the Nucleo defines.