### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,31 +6,31 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-PulseSensorPlayground KEYWORD1
+PulseSensorPlayground	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-analogInput KEYWORD2
-begin KEYWORD2
-blinkOnPulse  KEYWORD2
-fadeOnPulse KEYWORD2
-getBeatsPerMinute KEYWORD2
-getInterBeatIntervalMs  KEYWORD2
-getLatestSample KEYWORD2
-isInsideBeat  KEYWORD2
-outputBeat  KEYWORD2
-outputSample  KEYWORD2
-sawNewSample  KEYWORD2
-setSerial KEYWORD2
-setOutputType KEYWORD2
-sawStartOfBeat  KEYWORD2
-setThreshold  KEYWORD2
-getLastBeatTime KEYWORD2
-outputToSerial  KEYWORD2
-getPulseAmplitude KEYWORD2
-getLastBeatTime KEYWORD2
+analogInput	KEYWORD2
+begin	KEYWORD2
+blinkOnPulse	KEYWORD2
+fadeOnPulse	KEYWORD2
+getBeatsPerMinute	KEYWORD2
+getInterBeatIntervalMs	KEYWORD2
+getLatestSample	KEYWORD2
+isInsideBeat	KEYWORD2
+outputBeat	KEYWORD2
+outputSample	KEYWORD2
+sawNewSample	KEYWORD2
+setSerial	KEYWORD2
+setOutputType	KEYWORD2
+sawStartOfBeat	KEYWORD2
+setThreshold	KEYWORD2
+getLastBeatTime	KEYWORD2
+outputToSerial	KEYWORD2
+getPulseAmplitude	KEYWORD2
+getLastBeatTime	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)
@@ -40,6 +40,6 @@ getLastBeatTime KEYWORD2
 # Constants (LITERAL1)
 #######################################
 
-MICROS_PER_READ LITERAL1
-PROCESSING_VISUALIZER LITERAL1
-SERIAL_PLOTTER  LITERAL1
+MICROS_PER_READ	LITERAL1
+PROCESSING_VISUALIZER	LITERAL1
+SERIAL_PLOTTER	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords