### PR TITLE
fixed type error in updateLEDs()

### DIFF
--- a/src/utility/PulseSensor.cpp
+++ b/src/utility/PulseSensor.cpp
@@ -218,7 +218,12 @@ void PulseSensor::initializeLEDs() {
 
 void PulseSensor::updateLEDs() {
   if (BlinkPin >= 0) {
-    digitalWrite(BlinkPin, Pulse);
+    if (Pulse) {
+      digitalWrite(BlinkPin, HIGH);
+    }
+    else {
+      digitalWrite(BlinkPin, LOW);
+    }
   }
 
   if (FadePin >= 0) {


### PR DESCRIPTION
This compilation error was being thrown when compiling for the Arduino Uno WiFi Rev 2 board:

```
Users/annie/Documents/Arduino/libraries/PulseSensor_Playground/src/utility/PulseSensor.cpp: In member function 'void PulseSensor::updateLEDs()':
/Users/annie/Documents/Arduino/libraries/PulseSensor_Playground/src/utility/PulseSensor.cpp:221:33: error: cannot convert 'volatile boolean {aka volatile bool}' to 'PinStatus' for argument '2' to 'void digitalWrite(pin_size_t, PinStatus)'
     digitalWrite(BlinkPin, Pulse);
                                 ^
```

So I updated the call to digitalWrite() to now use HIGH or LOW as its second argument based on the state of Pulse. 