### PR TITLE
Added support for ESP32

### DIFF
--- a/src/utility/Interrupts.h
+++ b/src/utility/Interrupts.h
@@ -79,6 +79,11 @@
 // #include <FlexiTimer2.h>
 #endif
 
+// FOR BOARDS USING THE ESP32 WIFI MODULE
+#if defined(ARDUINO_ARCH_ESP32)
+// can't use analogWrite yet...
+#define NO_ANALOG_WRITE = 1
+#endif
 /*
    (internal to the library)
    Sets up the sample timer interrupt for this Arduino Platform.

--- a/src/utility/PulseSensor.cpp
+++ b/src/utility/PulseSensor.cpp
@@ -214,8 +214,10 @@ void PulseSensor::initializeLEDs() {
     digitalWrite(BlinkPin, LOW);
   }
   if (FadePin >= 0) {
+	#ifndef NO_ANALOG_WRITE
     pinMode(FadePin, OUTPUT);
     analogWrite(FadePin, 0); // turn off the LED.
+	#endif
   }
 }
 
@@ -229,6 +231,8 @@ void PulseSensor::updateLEDs() {
 	}
 
   if (FadePin >= 0) {
-    analogWrite(FadePin, FadeLevel / FADE_SCALE);
+		#ifndef NO_ANALOG_WRITE
+	    analogWrite(FadePin, FadeLevel / FADE_SCALE);
+		#endif
   }
 }


### PR DESCRIPTION
ESP32 does not support analogWrite yet, so I removed the analogWrite functions when ARDUINO_ARCH_ESP32 is defined.