### PR TITLE
Revert library name change

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,4 +1,4 @@
-name=PulseSensorPlayground
+name=PulseSensor Playground
 version=1.6.0
 author=Joel Murphy, Yury Gitman, Brad Needham
 maintainer=Joel Murphy, Yury Gitman


### PR DESCRIPTION
Libraries are locked to the `name` value specified by the library.properties metadata file in the release at the time of
the Library Manager submission.

Any release with a different name is rejected by the Arduino Library Manager indexer. The previous name change caused
the 1.6.0 release of the library to be rejected.

You can see this in the library's logs page here:

http://downloads.arduino.cc/libraries/logs/github.com/WorldFamousElectronics/PulseSensorPlayground/

```text
2022/04/24 02:05:39 Checking out tag: v1.6.0
2022/04/24 02:05:39 Release PulseSensorPlayground:1.6.0 has wrong library name, should be PulseSensor Playground
```

Reference: https://github.com/arduino/library-registry/blob/main/FAQ.md#update-requirements

> The name property in library.properties must not have changed from the value it had when the library was submitted.

It is possible to request Arduino for a library name change. However, I saw from https://github.com/WorldFamousElectronics/PulseSensorPlayground/pull/149 that the sole motivation for the name change was that releases were not picked up by Arduino Library Manager. The intended fix actually had the opposite of the intended result, so it might as well be reverted.

---

I didn't find the "v153" release mentioned by the PR message of https://github.com/WorldFamousElectronics/PulseSensorPlayground/pull/149 in the repo, but I do see a common problem with some of the other releases in the logs, so I suspect it was the same for 1.5.3.

I'll explain that problem, using the 1.4.10 release as the most straightforward example.

The problem is shown here in [the logs](http://downloads.arduino.cc/libraries/logs/github.com/WorldFamousElectronics/PulseSensorPlayground/):

```text
2022/04/24 02:05:39 Checking out tag: 1.4.10
2022/04/24 02:05:39 Release PulseSensor Playground:1.4.9 already loaded, skipping
```

Unfortunately, the logs don't communicate about this particular thing very well, but what this tells us is that the `version` value in [the `library.properties` metadata file](https://arduino.github.io/arduino-cli/latest/library-specification/#library-metadata) was not updated before creating the `1.4.10` tag (note that the indexer checked out tag `1.4.10`, only to find the release version was `1.4.9`).

You can see it here:

<https://github.com/WorldFamousElectronics/PulseSensorPlayground/blob/1.4.10/library.properties#L2>

```text
version=1.4.9
```

Even though [Git tags](https://git-scm.com/book/en/v2/Git-Basics-Tagging) are the unit of release for the Arduino Library Manager, all versioning is done according to the  `version` field of the [`library.properties` file](https://arduino.github.io/arduino-cli/latest/library-specification/#library-metadata). For this reason, the indexer will reject any tag that has the same value in its `version` field as a release already in the index.

So just make sure to always update the `version` field in the `library.properties` file before making a release.