### PR TITLE
fixed compile error to clarify error output message

### DIFF
--- a/examples/PulseSensor_Speaker/PulseSensor_Speaker.ino
+++ b/examples/PulseSensor_Speaker/PulseSensor_Speaker.ino
@@ -137,7 +137,7 @@ void loop() {
    */
   if (pulseSensor.sawStartOfBeat()) {
     pulseSensor.outputBeat();
-    tone(PIN_SPEAKER,1047);              // tone(pin,frequency)
+    tone(PIN_SPEAKER,932);              // tone(pin,frequency)
   }
 
   /*

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=PulseSensor Playground
-version=1.6.1
+version=1.6.2
 author=Joel Murphy, Yury Gitman, Brad Needham
 maintainer=Joel Murphy, Yury Gitman
 sentence=Support at PulseSensor.com

--- a/src/utility/Interrupts.h
+++ b/src/utility/Interrupts.h
@@ -64,7 +64,7 @@
 // The name is long to avoid collisions with Sketch and Library symbols.
 #if defined(__arc__)||(ARDUINO_SAMD_MKR1000)||(ARDUINO_SAMD_MKRZERO)||(ARDUINO_SAMD_ZERO)\
 ||(ARDUINO_ARCH_SAMD)||(ARDUINO_ARCH_STM32)||(ARDUINO_STM32_STAR_OTTO)||(ARDUINO_ARCH_NRF5)\
-||(ARDUINO_ARCH_NRF52)||(ARDUINO_ARCH_NRF52840)||(ARDUINO_NANO33BLE)
+||(ARDUINO_ARCH_NRF52)||(ARDUINO_ARCH_NRF52840)||(ARDUINO_NANO33BLE)||(ARDUINO_ARCH_RP2040)
 
 #define DISABLE_PULSE_SENSOR_INTERRUPTS
 #define ENABLE_PULSE_SENSOR_INTERRUPTS
@@ -236,8 +236,13 @@ boolean PulseSensorPlaygroundSetupInterrupt() {
     bitSet(TIMSK,6);   // Enable interrupt on match between TCNT1 and OCR1A
     ENABLE_PULSE_SENSOR_INTERRUPTS;
     return true;
+  #endif
 
-  #else
+  #if defined(__arc__)||(ARDUINO_SAMD_MKR1000)||(ARDUINO_SAMD_MKRZERO)||(ARDUINO_SAMD_ZERO)\
+  ||(ARDUINO_ARCH_SAMD)||(ARDUINO_ARCH_STM32)||(ARDUINO_STM32_STAR_OTTO)||(ARDUINO_ARCH_NRF5)\
+  ||(ARDUINO_ARCH_NRF52)||(ARDUINO_ARCH_NRF52840)||(ARDUINO_NANO33BLE)||(ARDUINO_ARCH_RP2040)
+
+    #error "Unsupported Board Selected! Try Using the example: PulseSensor_BPM_Alternative.ino"
     return false;      // unknown or unsupported platform.
   #endif
 


### PR DESCRIPTION
fixed a bug that caused compilation for some boards to crash with a cryptic warning. Now the IDE will print an error that tells the programmer to use BPM_Alternative.ino example.

Changed the frequency of the tone in Speaker example