### PR TITLE
Fix minor inaccuracy in example comments.

### DIFF
--- a/examples/PulseSensor_ESP32/PulseSensor_ESP32.ino
+++ b/examples/PulseSensor_ESP32/PulseSensor_ESP32.ino
@@ -214,7 +214,7 @@ void setup() {
   beginWiFi();
   
 /*
-   ESP32 analogRead defaults to 13 bit resolution
+   ESP32 analogRead defaults to 12 bit resolution
    PulseSensor Playground library works with 10 bit
 */
   analogReadResolution(10);


### PR DESCRIPTION
The ESP32 has a 12-bit ADC means it will give digital values in the range of 0 – 4096 (2^12). This PR fixes the comment that says it has a 13-bit ADC.