### PR TITLE
Add clang-format options file and format examples to a uniform style

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,35 @@
+# BasedOnStyle: Chromium
+---
+Language: Cpp
+AlignConsecutiveAssignments: true
+AlignConsecutiveBitFields: true
+AlignConsecutiveDeclarations: false
+AllowShortBlocksOnASingleLine: Empty
+AllowShortFunctionsOnASingleLine: Empty
+BinPackArguments: true
+BinPackParameters: true
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterFunction: false
+  BeforeCatch: true
+  BeforeElse: false
+ColumnLimit: 85
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ContinuationIndentWidth: 2  # Same as TabWidth
+DerivePointerAlignment: true
+IndentAccessModifiers: true
+IndentCaseLabels: false
+IndentPPDirectives: BeforeHash
+IndentWidth: 2  # Same as TabWidth
+MaxEmptyLinesToKeep: 2
+PenaltyExcessCharacter: 2
+PointerAlignment: Right
+ReferenceAlignment: Left
+ReflowComments: IndentOnly
+SkipMacroDefinitionBody: true
+SortIncludes: Never
+SpaceAfterCStyleCast: true
+SpaceAfterTemplateKeyword: false
+SpacesBeforeTrailingComments: 2
+TabWidth: 2
+UseTab: Never

--- a/examples/GettingStartedProject/GettingStartedProject.ino
+++ b/examples/GettingStartedProject/GettingStartedProject.ino
@@ -21,38 +21,33 @@
 
 
 //  Variables
-int PulseSensorPurplePin = 0;        // Pulse Sensor PURPLE WIRE connected to ANALOG PIN 0
-int LED = LED_BUILTIN;   //  The on-board Arduion LED
+int PulseSensorPurplePin = 0;  // Pulse Sensor PURPLE WIRE connected to ANALOG PIN 0
+int LED = LED_BUILTIN;         //  The on-board Arduion LED
 
 
-int Signal;                // holds the incoming raw data. Signal value can range from 0-1024
-int Threshold = 580;       // Determine which Signal to "count as a beat", and which to ingore.
+int Signal;           // holds the incoming raw data. Signal value can range from 0-1024
+int Threshold = 580;  // Determine which Signal to "count as a beat", and which to ingore.
 
 
 // The SetUp Function:
 void setup() {
-  pinMode(LED,OUTPUT);         // pin that will blink to your heartbeat!
-   Serial.begin(115200);       // Set's up Serial Communication at certain speed.
-
+  pinMode(LED, OUTPUT);  // pin that will blink to your heartbeat!
+  Serial.begin(115200);  // Set's up Serial Communication at certain speed.
 }
 
 // The Main Loop Function
 void loop() {
 
   Signal = analogRead(PulseSensorPurplePin);  // Read the PulseSensor's value.
-                                              // Assign this value to the "Signal" variable.
+  // Assign this value to the "Signal" variable.
 
-   Serial.println("Signal " + String(Signal)); // Send "reading " followed by the Signal value to Serial Plotter.
+  Serial.println("Signal " + String(Signal));  // Send "reading " followed by the Signal value to Serial Plotter.
 
+  if (Signal > Threshold) {  // If the signal is above "550", then "turn-on" Arduino's on-Board LED.
+    digitalWrite(LED, HIGH);
+  } else {
+    digitalWrite(LED, LOW);  //  Else, the sigal must be below "550", so "turn-off" this LED.
+  }
 
-   if(Signal > Threshold){                          // If the signal is above "550", then "turn-on" Arduino's on-Board LED.
-     digitalWrite(LED,HIGH);
-   } else {
-     digitalWrite(LED,LOW);                //  Else, the sigal must be below "550", so "turn-off" this LED.
-   }
-
-
-delay(20);
-
-
+  delay(20);
 }

--- a/examples/Getting_BPM_to_Monitor/Getting_BPM_to_Monitor.ino
+++ b/examples/Getting_BPM_to_Monitor/Getting_BPM_to_Monitor.ino
@@ -9,49 +9,44 @@
 4) Blinks the builtin LED with user's Heartbeat.
 --------------------------------------------------------------------*/
 
-#include <PulseSensorPlayground.h>     // Includes the PulseSensorPlayground Library.   
+#include <PulseSensorPlayground.h>  // Includes the PulseSensorPlayground Library.
 
 //  Variables
-const int PulseWire = 0;       // PulseSensor PURPLE WIRE connected to ANALOG PIN 0
-const int LED = LED_BUILTIN;          // The on-board Arduino LED, close to PIN 13.
-int Threshold = 550;           // Determine which Signal to "count as a beat" and which to ignore.
-                               // Use the "Gettting Started Project" to fine-tune Threshold Value beyond default setting.
-                               // Otherwise leave the default "550" value. 
-                               
+const int PulseWire = 0;      // PulseSensor PURPLE WIRE connected to ANALOG PIN 0
+const int LED = LED_BUILTIN;  // The on-board Arduino LED, close to PIN 13.
+int Threshold = 550;          // Determine which Signal to "count as a beat" and which to ignore.
+                              // Use the "Gettting Started Project" to fine-tune Threshold Value beyond default setting.
+                              // Otherwise leave the default "550" value.
+
 PulseSensorPlayground pulseSensor;  // Creates an instance of the PulseSensorPlayground object called "pulseSensor"
 
 
-void setup() {   
+void setup() {
 
-  Serial.begin(115200);          // For Serial Monitor
+  Serial.begin(115200);  // For Serial Monitor
 
-  // Configure the PulseSensor object, by assigning our variables to it. 
-  pulseSensor.analogInput(PulseWire);   
-  pulseSensor.blinkOnPulse(LED);       //auto-magically blink Arduino's LED with heartbeat.
-  pulseSensor.setThreshold(Threshold);   
+  // Configure the PulseSensor object, by assigning our variables to it.
+  pulseSensor.analogInput(PulseWire);
+  pulseSensor.blinkOnPulse(LED);  // auto-magically blink Arduino's LED with heartbeat.
+  pulseSensor.setThreshold(Threshold);
 
-  // Double-check the "pulseSensor" object was created and "began" seeing a signal. 
-   if (pulseSensor.begin()) {
-    Serial.println("We created a pulseSensor Object !");  //This prints one time at Arduino power-up,  or on Arduino reset.  
+  // Double-check the "pulseSensor" object was created and "began" seeing a signal.
+  if (pulseSensor.begin()) {
+    Serial.println("We created a pulseSensor Object !");  // This prints one time at Arduino power-up,  or on Arduino reset.
   }
 }
 
 
-
 void loop() {
 
- 
 
-if (pulseSensor.sawStartOfBeat()) {            // Constantly test to see if "a beat happened".
-int myBPM = pulseSensor.getBeatsPerMinute();  // Calls function on our pulseSensor object that returns BPM as an "int".
-                                               // "myBPM" hold this BPM value now. 
- Serial.println("♥  A HeartBeat Happened ! "); // If test is "true", print a message "a heartbeat happened".
- Serial.print("BPM: ");                        // Print phrase "BPM: " 
- Serial.println(myBPM);                        // Print the value inside of myBPM. 
+  if (pulseSensor.sawStartOfBeat()) {              // Constantly test to see if "a beat happened".
+    int myBPM = pulseSensor.getBeatsPerMinute();   // Calls function on our pulseSensor object that returns BPM as an "int".
+                                                   // "myBPM" hold this BPM value now.
+    Serial.println("♥  A HeartBeat Happened ! ");  // If test is "true", print a message "a heartbeat happened".
+    Serial.print("BPM: ");                         // Print phrase "BPM: "
+    Serial.println(myBPM);                         // Print the value inside of myBPM.
+  }
+
+  delay(20);  // considered best practice in a simple sketch.
 }
-
-  delay(20);                    // considered best practice in a simple sketch.
-
-}
-
-  

--- a/examples/PulseSensorLIbrary_V2_System_Test/PulseSensorLIbrary_V2_System_Test.ino
+++ b/examples/PulseSensorLIbrary_V2_System_Test/PulseSensorLIbrary_V2_System_Test.ino
@@ -11,27 +11,21 @@
     getPulseAmplitude()
     getLastBeatTime()
   All other functionality is implicitly tested by successfully running the program.
-  
 
+  Check out the PulseSensor Playground Tools for explaination
+  of all user functions and directives.
+  https://github.com/WorldFamousElectronics/PulseSensorPlayground/blob/master/resources/PulseSensor%20Playground%20Tools.md
 
-   Check out the PulseSensor Playground Tools for explaination
-   of all user functions and directives.
-   https://github.com/WorldFamousElectronics/PulseSensorPlayground/blob/master/resources/PulseSensor%20Playground%20Tools.md
+  Copyright World Famous Electronics LLC - see LICENSE
+  Contributors:
+    Joel Murphy, https://pulsesensor.com
+    Yury Gitman, https://pulsesensor.com
+    Bradford Needham, @bneedhamia, https://bluepapertech.com
 
-   Copyright World Famous Electronics LLC - see LICENSE
-   Contributors:
-     Joel Murphy, https://pulsesensor.com
-     Yury Gitman, https://pulsesensor.com
-     Bradford Needham, @bneedhamia, https://bluepapertech.com
+  Licensed under the MIT License, a copy of which
+  should have been included with this software.
 
-   Licensed under the MIT License, a copy of which
-   should have been included with this software.
-
-   This software is not intended for medical use.
-*/
-
-/*
-   Test notes here
+  This software is not intended for medical use.
 */
 
 #include <PulseSensorPlayground.h>
@@ -41,8 +35,8 @@
 unsigned long thisTime;
 bool testing = false;
 bool normal = false;
-uint8_t errorCode = 0x00; // maybe used for anything automatic?
-int testBPM, testIBI, testAmp, testLastBeatTime; // test variables
+uint8_t errorCode = 0x00;  // maybe used for anything automatic?
+int testBPM, testIBI, testAmp, testLastBeatTime;  // test variables
 int beatCounter;
 int firstBeatTime, lastBeatTime, firstToLastBeatTime;
 
@@ -51,7 +45,7 @@ const int OUTPUT_TYPE = SERIAL_PLOTTER;
 const int PULSE_INPUT = A0;
 const int PULSE_BLINK = LED_BUILTIN;
 const int PULSE_FADE = 5;
-const int THRESHOLD = 550;   // Adjust this number to avoid noise when idle
+const int THRESHOLD = 550;  // Adjust this number to avoid noise when idle
 
 PulseSensorPlayground pulseSensor;
 
@@ -69,17 +63,18 @@ void setup() {
   // Now that everything is ready, start reading the PulseSensor signal.
   if (!pulseSensor.begin()) {
     /*
-       PulseSensor initialization failed,
-       likely because our particular Arduino platform interrupts
-       aren't supported yet.
+      PulseSensor initialization failed,
+      likely because our particular Arduino platform interrupts
+      aren't supported yet.
 
-       If your Sketch hangs here, try PulseSensor_BPM_Alternative.ino,
-       which doesn't use interrupts.
+      If your Sketch hangs here, try PulseSensor_BPM_Alternative.ino,
+      which doesn't use interrupts.
     */
-    for(;;) {
+    for (;;) {
       // Flash the led to show things didn't work.
       digitalWrite(PULSE_BLINK, LOW);
-      delay(50); Serial.println('!');
+      delay(50);
+      Serial.println('!');
       digitalWrite(PULSE_BLINK, HIGH);
       delay(50);
     }
@@ -87,24 +82,23 @@ void setup() {
   pulseSensor.pause();
   delay(100);
   printInstructions();
-  
 }
 
 void loop() {
-  if(testing){
+  if (testing) {
     runTest(millis());
   }
-  if(normal){
+  if (normal) {
     runNormal();
   }
   checkSerial();
-} // loop
+}  // loop
 
 
 /*
-  Receives millis() and runs a test for TEST_DURATION 
+  Receives millis() and runs a test for TEST_DURATION
 */
-void runTest(unsigned long startTime){
+void runTest(unsigned long startTime) {
   beatCounter = 0;  // reset the beat counter
   testIBI = 0;
   testBPM = 0;
@@ -112,13 +106,15 @@ void runTest(unsigned long startTime){
   firstBeatTime = -1;
   lastBeatTime = -1;
   Serial.println("\n\tSTART TEST");
-  pulseSensor.resume(); // start the sensing!
-  while((millis() - startTime) < TEST_DURATION){
-    Serial.println(pulseSensor.getLatestSample()); // print raw data for plotter or monitor review
-    if(pulseSensor.sawStartOfBeat()){
+  pulseSensor.resume();  // start the sensing!
+  while ((millis() - startTime) < TEST_DURATION) {
+    Serial.println(pulseSensor.getLatestSample());  // print raw data for plotter or monitor review
+    if (pulseSensor.sawStartOfBeat()) {
       beatCounter++;
-      if(firstBeatTime < 0){ firstBeatTime = pulseSensor.getLastBeatTime(); }
-      testBPM += pulseSensor.getBeatsPerMinute(); 
+      if (firstBeatTime < 0) {
+        firstBeatTime = pulseSensor.getLastBeatTime();
+      }
+      testBPM += pulseSensor.getBeatsPerMinute();
       testIBI += pulseSensor.getInterBeatIntervalMs();
       testAmp += pulseSensor.getPulseAmplitude();
     }
@@ -135,11 +131,11 @@ void runTest(unsigned long startTime){
   printInstructions();
   testing = false;
 }
-    
 
-void runNormal(){
-  if(pulseSensor.UsingHardwareTimer){
-    delay(20); 
+
+void runNormal() {
+  if (pulseSensor.UsingHardwareTimer) {
+    delay(20);
     pulseSensor.outputSample();
   } else {
     if (pulseSensor.sawNewSample()) {

--- a/examples/PulseSensorLIbrary_V2_System_Test/serialStuff.ino
+++ b/examples/PulseSensorLIbrary_V2_System_Test/serialStuff.ino
@@ -2,10 +2,10 @@
 
 */
 
-void checkSerial(){
-  if(Serial.available()){
+void checkSerial() {
+  if (Serial.available()) {
     char inChar = Serial.read();
-    switch(inChar){
+    switch (inChar) {
       case 't':
         testing = true;
         break;
@@ -19,29 +19,31 @@ void checkSerial(){
         printInstructions();
         break;
       default:
-        Serial.print("i got "); Serial.println(inChar);
+        Serial.print("I got ");
+        Serial.println(inChar);
     }
-  } // Serial.available
-} // checkSerial
+  }  // Serial.available
+}  // checkSerial
 
 
-void printResults(){
-  float durationOfBeats = float(firstToLastBeatTime/1000.0);
-  Serial.println("\tTEST COMPLETE"); 
+void printResults() {
+  float durationOfBeats = float(firstToLastBeatTime / 1000.0);
+  Serial.println("\tTEST COMPLETE");
   Serial.print("\tAverage BPM: "); Serial.println(testBPM);
   Serial.print("\tAverage IBI: "); Serial.println(testIBI);
   Serial.print("\tAverage Pulse Amplitude: "); Serial.println(testAmp);
-  Serial.print("\tFirst to last heartbeat time: "); Serial.print(durationOfBeats,3); Serial.println(" Seconds"); 
+  Serial.print("\tFirst to last heartbeat time: "); Serial.print(durationOfBeats, 3); Serial.println(" Seconds");
   Serial.print("\tPlayground Library is using a ");
-  if(pulseSensor.UsingHardwareTimer){
+  if (pulseSensor.UsingHardwareTimer) {
     Serial.println("hardware timer");
   } else {
     Serial.println("software timer");
   }
 }
 
-void printInstructions(){
-  Serial.print("\nPulseSensor Playground "); Serial.println(PULSESENSOR_PLAYGROUND_VERSION_STRING);
+void printInstructions() {
+  Serial.print("\nPulseSensor Playground ");
+  Serial.println(PULSESENSOR_PLAYGROUND_VERSION_STRING);
   Serial.println("Full System Test Instructions:");
   Serial.println("\n\t1) Connect PulseSensor wires to the board under test");
   Serial.println("\t2) Use a known good signal source to connect PulseSensor to");
@@ -52,7 +54,7 @@ void printInstructions(){
   Serial.println("\nSend 'r' to run the pulseSensor with normal output");
   Serial.println("Send 'p' to pause normal output, and print this message");
   Serial.print("PulseSensor is currently ");
-  if(pulseSensor.isPaused()){
+  if (pulseSensor.isPaused()) {
     Serial.println("paused");
   } else {
     Serial.println("running!");

--- a/examples/PulseSensor_ATtiny85_Serial/PulseSensor_ATtiny85_Serial.ino
+++ b/examples/PulseSensor_ATtiny85_Serial/PulseSensor_ATtiny85_Serial.ino
@@ -61,17 +61,17 @@ const int OUTPUT_TYPE = PROCESSING_VISUALIZER;
       Adjust as neccesary.
 */
 const int PULSE_INPUT = A1;
-const int PULSE_BLINK = 1;    // Pin 13 is the on-board LED
+const int PULSE_BLINK = 1;  // Pin 13 is the on-board LED
 const int PULSE_FADE = 0;
-const int THRESHOLD = 550;   // Adjust this number to avoid noise when idle
-const int TX_PIN = 3;        // Using software serial
+const int THRESHOLD = 550;  // Adjust this number to avoid noise when idle
+const int TX_PIN = 3;       // Using software serial
 const int RX_PIN = 4;
 
 /*
    All the PulseSensor Playground functions.
 */
 PulseSensorPlayground pulseSensor;
-SoftwareSerial pulseUART(TX_PIN,RX_PIN);
+SoftwareSerial pulseUART(TX_PIN, RX_PIN);
 
 void setup() {
   /*
@@ -105,7 +105,7 @@ void setup() {
        If your Sketch hangs here, try PulseSensor_BPM_Alternative.ino,
        which doesn't use interrupts.
     */
-    for(;;) {
+    for (;;) {
       // Flash the led to show things didn't work.
       digitalWrite(PULSE_BLINK, LOW);
       delay(50);
@@ -127,44 +127,44 @@ void loop() {
      will check to see how much time has passed, then read
      and process a sample (analog voltage) from the PulseSensor.
      Call this function often to maintain 500Hz sample rate,
-     that is every 2 milliseconds. Best not to have any delay() 
+     that is every 2 milliseconds. Best not to have any delay()
      functions in the loop when using a software timer.
 
      Check the compatibility of your hardware at this link
      <url>
      and delete the unused code portions in your saved copy, if you like.
   */
-if(pulseSensor.UsingHardwareTimer){
-  /*
-     Wait a bit.
-     We don't output every sample, because our baud rate
-     won't support that much I/O.
-  */
-  delay(20); 
-  // write the latest sample to Serial.
-  pulseSensor.outputSample();
-} else {
-/*
-    When using a software timer, we have to check to see if it is time
-    to acquire another sample. A call to sawNewSample will do that.
-*/
-  if (pulseSensor.sawNewSample()) {
+  if (pulseSensor.UsingHardwareTimer) {
     /*
+      Wait a bit.
+      We don't output every sample, because our baud rate
+      won't support that much I/O.
+    */
+    delay(20);
+    // write the latest sample to Serial.
+    pulseSensor.outputSample();
+  } else {
+    /*
+      When using a software timer, we have to check to see if it is time
+      to acquire another sample. A call to sawNewSample will do that.
+    */
+    if (pulseSensor.sawNewSample()) {
+      /*
         Every so often, send the latest Sample.
         We don't print every sample, because our baud rate
         won't support that much I/O.
-    */
-    if (--pulseSensor.samplesUntilReport == (byte) 0) {
-      pulseSensor.samplesUntilReport = SAMPLES_PER_SERIAL_SAMPLE;
-      pulseSensor.outputSample();
+      */
+      if (--pulseSensor.samplesUntilReport == (byte) 0) {
+        pulseSensor.samplesUntilReport = SAMPLES_PER_SERIAL_SAMPLE;
+        pulseSensor.outputSample();
+      }
     }
   }
-}
   /*
-     If a beat has happened since we last checked,
-     write the per-beat information to Serial.
-   */
-    if (pulseSensor.sawStartOfBeat()) {
-      pulseSensor.outputBeat();
-    }
+    If a beat has happened since we last checked,
+    write the per-beat information to Serial.
+  */
+  if (pulseSensor.sawStartOfBeat()) {
+    pulseSensor.outputBeat();
+  }
 }

--- a/examples/PulseSensor_ATtiny85_noSerial/PulseSensor_ATtiny85_noSerial.ino
+++ b/examples/PulseSensor_ATtiny85_noSerial/PulseSensor_ATtiny85_noSerial.ino
@@ -49,9 +49,9 @@
       Adjust as neccesary.
 */
 const int PULSE_INPUT = A1;
-const int PULSE_BLINK = 1;    // Pin 13 is the on-board LED
+const int PULSE_BLINK = 1;  // Pin 13 is the on-board LED
 const int PULSE_FADE = 0;
-const int THRESHOLD = 550;   // Adjust this number to avoid noise when idle
+const int THRESHOLD = 550;  // Adjust this number to avoid noise when idle
 
 /*
    All the PulseSensor Playground functions.
@@ -76,7 +76,7 @@ void setup() {
        If your Sketch hangs here, try PulseSensor_BPM_Alternative.ino,
        which doesn't use interrupts.
     */
-    for(;;) {
+    for (;;) {
       // Flash the led to show things didn't work.
       digitalWrite(PULSE_BLINK, LOW);
       delay(50);
@@ -89,9 +89,9 @@ void setup() {
 void loop() {
   /*
      When we're not outputting serial messages
-		 there's not much to do here.
-		 In case you want to add more behavior to the sketch
-		 you can use sawStartOfBeat() or isInsideBeat()
-		 to have the sketch do stuff when there's a beat.
+     there's not much to do here.
+     In case you want to add more behavior to the sketch
+     you can use sawStartOfBeat() or isInsideBeat()
+     to have the sketch do stuff when there's a beat.
   */
 }

--- a/examples/PulseSensor_BPM/PulseSensor_BPM.ino
+++ b/examples/PulseSensor_BPM/PulseSensor_BPM.ino
@@ -67,7 +67,7 @@ const int OUTPUT_TYPE = SERIAL_PLOTTER;
 const int PULSE_INPUT = A0;
 const int PULSE_BLINK = LED_BUILTIN;
 const int PULSE_FADE = 5;
-const int THRESHOLD = 550;   // Adjust this number to avoid noise when idle
+const int THRESHOLD = 550;  // Adjust this number to avoid noise when idle
 
 /*
    All the PulseSensor Playground functions.
@@ -106,10 +106,11 @@ void setup() {
        If your Sketch hangs here, try PulseSensor_BPM_Alternative.ino,
        which doesn't use interrupts.
     */
-    for(;;) {
+    for (;;) {
       // Flash the led to show things didn't work.
       digitalWrite(PULSE_BLINK, LOW);
-      delay(50); Serial.println('!');
+      delay(50);
+      Serial.println('!');
       digitalWrite(PULSE_BLINK, HIGH);
       delay(50);
     }
@@ -117,56 +118,56 @@ void setup() {
 }
 
 void loop() {
-   /*
-     See if a sample is ready from the PulseSensor.
-
-     If USE_HARDWARE_TIMER is true, the PulseSensor Playground
-     will automatically read and process samples from
-     the PulseSensor.
-
-     If USE_HARDWARE_TIMER is false, the call to sawNewSample()
-     will check to see how much time has passed, then read
-     and process a sample (analog voltage) from the PulseSensor.
-     Call this function often to maintain 500Hz sample rate,
-     that is every 2 milliseconds. Best not to have any delay() 
-     functions in the loop when using a software timer.
-
-     Check the compatibility of your hardware at this link
-     <url>
-     and delete the unused code portions in your saved copy, if you like.
-  */
-if(pulseSensor.UsingHardwareTimer){
   /*
-     Wait a bit.
-     We don't output every sample, because our baud rate
-     won't support that much I/O.
-  */
-  delay(20); 
-  // write the latest sample to Serial.
-  pulseSensor.outputSample();
-} else {
-/*
-    When using a software timer, we have to check to see if it is time
-    to acquire another sample. A call to sawNewSample will do that.
-*/
-  if (pulseSensor.sawNewSample()) {
+    See if a sample is ready from the PulseSensor.
+
+    If USE_HARDWARE_TIMER is true, the PulseSensor Playground
+    will automatically read and process samples from
+    the PulseSensor.
+
+    If USE_HARDWARE_TIMER is false, the call to sawNewSample()
+    will check to see how much time has passed, then read
+    and process a sample (analog voltage) from the PulseSensor.
+    Call this function often to maintain 500Hz sample rate,
+    that is every 2 milliseconds. Best not to have any delay()
+    functions in the loop when using a software timer.
+
+    Check the compatibility of your hardware at this link
+    <url>
+    and delete the unused code portions in your saved copy, if you like.
+ */
+  if (pulseSensor.UsingHardwareTimer) {
     /*
+       Wait a bit.
+       We don't output every sample, because our baud rate
+       won't support that much I/O.
+    */
+    delay(20);
+    // write the latest sample to Serial.
+    pulseSensor.outputSample();
+  } else {
+    /*
+      When using a software timer, we have to check to see if it is time
+      to acquire another sample. A call to sawNewSample will do that.
+    */
+    if (pulseSensor.sawNewSample()) {
+      /*
         Every 20 milliseconds, send the latest Sample.
         We don't print every sample, because our baud rate
         won't support that much I/O.
-    */
-    if ((pulseSensor.samplesUntilReport--) == 0) {
-      pulseSensor.samplesUntilReport = SAMPLES_PER_SERIAL_SAMPLE;
-      pulseSensor.outputSample();
+      */
+      if ((pulseSensor.samplesUntilReport--) == 0) {
+        pulseSensor.samplesUntilReport = SAMPLES_PER_SERIAL_SAMPLE;
+        pulseSensor.outputSample();
+      }
     }
   }
-}
   /*
-     If a beat has happened since we last checked,
-     write the per-beat information to Serial, formatted as CSV:
-     BPM, IBI, PulseSensor Signal
-   */
-    if (pulseSensor.sawStartOfBeat()) {
-      pulseSensor.outputBeat();
-    }
+    If a beat has happened since we last checked,
+    write the per-beat information to Serial, formatted as CSV:
+    BPM, IBI, PulseSensor Signal
+  */
+  if (pulseSensor.sawStartOfBeat()) {
+    pulseSensor.outputBeat();
+  }
 }

--- a/examples/PulseSensor_ESP32/PulseSensor_ESP32.ino
+++ b/examples/PulseSensor_ESP32/PulseSensor_ESP32.ino
@@ -37,11 +37,11 @@
 
 /*
    The following libraries are necessary
-   for the asynchronous web server 
+   for the asynchronous web server
 */
 #include <Arduino.h>
 #include <WiFi.h>
-#include <AsyncTCP.h> // https://github.com/dvarrel/ESPAsyncTCP
+#include <AsyncTCP.h>          // https://github.com/dvarrel/ESPAsyncTCP
 #include <ESPAsyncWebServer.h> // https://github.com/dvarrel/ESPAsyncWebSrv
 #include <Arduino_JSON.h>
 
@@ -83,26 +83,26 @@ PulseSensorPlayground pulseSensor;
       Adjust as neccesary.
 */
 const int PULSE_INPUT = A0;
-const int PULSE_BLINK = 13;    
+const int PULSE_BLINK = 13;
 const int PULSE_FADE = 5;
-const int THRESHOLD = 685;   
+const int THRESHOLD = 685;
 
 /*  Replace with your network credentials  */
-const char* ssid = "SSID";
-const char* password = "PASSWORD";
+const char *ssid = "SSID";
+const char *password = "PASSWORD";
 
-/* 
-    Create AsyncWebServer object on port 80
-    Create an Event Source on /events
+/*
+  Create AsyncWebServer object on port 80
+  Create an Event Source on /events
 */
 AsyncWebServer server(80);
 AsyncEventSource events("/events");
 
 /*
-    The following code between the two "rawliteral" tags
-    will be stored as text. It contains the html,
-    css, and javascript that will be used to build
-    the asynchronous server.
+  The following code between the two "rawliteral" tags
+  will be stored as text. It contains the html,
+  css, and javascript that will be used to build
+  the asynchronous server.
 */
 const char index_html[] PROGMEM = R"rawliteral(
 <!DOCTYPE HTML html>
@@ -112,14 +112,14 @@ const char index_html[] PROGMEM = R"rawliteral(
     <link rel="icon" href="data:,">
       <style>
       html {
-        font-family: Arial; 
-        display: inline-block; 
+        font-family: Arial;
+        display: inline-block;
         margin: 0px auto;
         text-align: center;
       }
       h2 { font-size: 3.0rem; }
       p { font-size: 3.0rem; }
-      .reading { 
+      .reading {
         font-size: 2.0rem;
         color:black;
       }
@@ -130,11 +130,11 @@ const char index_html[] PROGMEM = R"rawliteral(
   </head>
   <body>
       <h2>PulseSensor Server</h2>
-      <p 
+      <p
         <span class="reading"> Heart Rate</span>
         <span id="bpm"></span>
         <span class="dataType">bpm</span>
-      </p> 
+      </p>
   </body>
 <script>
 window.addEventListener('load', getData);
@@ -147,7 +147,7 @@ function getData(){
       console.log(Jobj);
       document.getElementById("bpm").innerHTML = Jobj.heartrate;
     }
-  }; 
+  };
   xhr.open("GET", "/data", true);
   xhr.send();
 }
@@ -175,16 +175,16 @@ if (!!window.EventSource) {
 </html>)rawliteral";
 
 /*  Package the BPM in a JSON object  */
-String updatePulseDataJson(){
+String updatePulseDataJson() {
   pulseData["heartrate"] = String(pulseSensor.getBeatsPerMinute());
   String jsonString = JSON.stringify(pulseData);
   return jsonString;
 }
 
 
-/* 
-    Begin the WiFi and print the server url
-    to the serial port on connection
+/*
+  Begin the WiFi and print the server url
+  to the serial port on connection
 */
 void beginWiFi() {
   WiFi.mode(WIFI_STA);
@@ -198,74 +198,74 @@ void beginWiFi() {
   Serial.println("\nConnected");
 }
 
-/* 
-   When sendPulseSignal is true, PulseSensor Signal data
-   is sent to the serial port for user monitoring.
-   Modified by keys received on the Serial port.
-   Use the Serial Plotter to view the PulseSensor Signal wave.
+/*
+  When sendPulseSignal is true, PulseSensor Signal data
+  is sent to the serial port for user monitoring.
+  Modified by keys received on the Serial port.
+  Use the Serial Plotter to view the PulseSensor Signal wave.
 */
 bool sendPulseSignal = false;
 
 void setup() {
-/*
-   115200 baud provides about 11 bytes per millisecond.
-   The delay allows the port to settle so that 
-   we don't miss out on info about the server url
-   in the Serial Monitor so we can connect a browser.
-*/
+  /*
+    115200 baud provides about 11 bytes per millisecond.
+    The delay allows the port to settle so that
+    we don't miss out on info about the server url
+    in the Serial Monitor so we can connect a browser.
+  */
   Serial.begin(115200);
-  delay(1500); 
+  delay(1500);
   beginWiFi();
-  
-/*
-   ESP32 analogRead defaults to 12 bit resolution
-   PulseSensor Playground library works with 10 bit
-*/
+
+  /*
+    ESP32 analogRead defaults to 12 bit resolution
+    PulseSensor Playground library works with 10 bit
+  */
   analogReadResolution(10);
-  
-/*  Configure the PulseSensor manager  */
+
+  /*  Configure the PulseSensor manager  */
   pulseSensor.analogInput(PULSE_INPUT);
   pulseSensor.blinkOnPulse(PULSE_BLINK);
   pulseSensor.fadeOnPulse(PULSE_FADE);
   pulseSensor.setSerial(Serial);
   pulseSensor.setThreshold(THRESHOLD);
 
-/*  Now that everything is ready, start reading the PulseSensor signal. */
+  /*  Now that everything is ready, start reading the PulseSensor signal. */
   if (!pulseSensor.begin()) {
-    while(1) {
-/*  If the pulseSensor object fails, flash the led  */
+    while (1) {
+      /*  If the pulseSensor object fails, flash the led  */
       digitalWrite(PULSE_BLINK, LOW);
       delay(50);
       digitalWrite(PULSE_BLINK, HIGH);
       delay(50);
     }
   }
-  
 
-/* 
+
+  /*
     When the server gets a request for the root url
     serve the html
-*/
+  */
   server.on("/", HTTP_GET, [](AsyncWebServerRequest *request) {
-    request->send(200, "text/html", index_html); 
+    request->send(200, "text/html", index_html);
   });
 
-  
-/*  Request for the latest PulseSensor data  */
+
+  /*  Request for the latest PulseSensor data  */
   server.on("/data", HTTP_GET, [](AsyncWebServerRequest *request) {
     String json = updatePulseDataJson();
     request->send(200, "application/json", json);
     json = String();
   });
 
-/*  
-    Handler for when a client connects to the server  
-    Only send serial feedback when NOT sending PulseSensor Signal data
-    Send event with short message and set reconnect timer to 2 seconds
-*/
+  /*
+      Handler for when a client connects to the server
+      Only send serial feedback when NOT sending PulseSensor Signal data
+      Send event with short message and set reconnect timer to 2 seconds
+  */
   events.onConnect([](AsyncEventSourceClient *client) {
-    if(!sendPulseSignal){
-      if(client->lastId()){
+    if (!sendPulseSignal) {
+      if (client->lastId()) {
         Serial.println("Client Reconnected");
       } else {
         Serial.println("New Client Connected");
@@ -273,55 +273,54 @@ void setup() {
     }
     client->send("hello", NULL, millis(), 20000);
   });
-  
-/*  Create a handler for events  */
+
+  /*  Create a handler for events  */
   server.addHandler(&events);
 
-/*  Start the server  */
+  /*  Start the server  */
   server.begin();
 
-/*  Print the control information to the serial monitor  */
+  /*  Print the control information to the serial monitor  */
   printControlInfo();
-  
 }
 
 void loop() {
-/*
-     Option to send the PulseSensor Signal data
-     to serial port for verification
-*/
-  if(sendPulseSignal){
+  /*
+    Option to send the PulseSensor Signal data
+    to serial port for verification
+  */
+  if (sendPulseSignal) {
     delay(20);
     Serial.println(pulseSensor.getLatestSample());
   }
 
-  
-/*
-     If a beat has happened since we last checked,
-     update the json data file to the server.
-     Also, send the new BPM value to the serial port
-     if we are not monitoring the pulse signal.
-*/
+
+  /*
+    If a beat has happened since we last checked,
+    update the json data file to the server.
+    Also, send the new BPM value to the serial port
+    if we are not monitoring the pulse signal.
+  */
   if (pulseSensor.sawStartOfBeat()) {
-    events.send(updatePulseDataJson().c_str(),"new_data" ,millis());
-    if(!sendPulseSignal){
+    events.send(updatePulseDataJson().c_str(), "new_data", millis());
+    if (!sendPulseSignal) {
       Serial.print(pulseSensor.getBeatsPerMinute());
       Serial.println(" bpm");
     }
   }
-/*  Check to see if there are any commands sent to us  */
-   serialCheck();
+  /*  Check to see if there are any commands sent to us  */
+  serialCheck();
 }
 
 /*
-    This function checks to see if there are any commands available
-    on the Serial port. When you send keyboard characters 'b' or 'x'
-    you can turn on and off the signal data stream.
+  This function checks to see if there are any commands available
+  on the Serial port. When you send keyboard characters 'b' or 'x'
+  you can turn on and off the signal data stream.
 */
-void serialCheck(){
-  if(Serial.available() > 0){
+void serialCheck() {
+  if (Serial.available() > 0) {
     char inChar = Serial.read();
-    switch(inChar){
+    switch (inChar) {
       case 'b':
         sendPulseSignal = true;
         break;
@@ -329,7 +328,7 @@ void serialCheck(){
         sendPulseSignal = false;
         break;
       case '?':
-        if(!printControlInfo){
+        if (!printControlInfo) {
           printControlInfo();
         }
         break;
@@ -340,9 +339,9 @@ void serialCheck(){
 }
 
 /*
-    This function prints the control information to the serial monitor
+  This function prints the control information to the serial monitor
 */
-void printControlInfo(){
+void printControlInfo() {
   Serial.println("PulseSensor ESP32 Example");
   Serial.print("\nPulseSensor Server url: ");
   Serial.println(WiFi.localIP());
@@ -350,5 +349,3 @@ void printControlInfo(){
   Serial.println("Send 'x' to stop sending PulseSensor signal data");
   Serial.println("Send '?' to print this message");
 }
-
-

--- a/examples/PulseSensor_Pulse_Transit_Time/PulseSensor_Pulse_Transit_Time.ino
+++ b/examples/PulseSensor_Pulse_Transit_Time/PulseSensor_Pulse_Transit_Time.ino
@@ -29,44 +29,44 @@
 */
 
 /*
-   Include the PulseSensor Playground library to get all the good stuff!
-   The PulseSensor Playground library will decide whether to use
-   a hardware timer to get accurate sample readings by checking
-   what target hardware is being used and adjust accordingly.
-   You may see a "warning" come up in red during compilation
-   if a hardware timer is not being used.
+  Include the PulseSensor Playground library to get all the good stuff!
+  The PulseSensor Playground library will decide whether to use
+  a hardware timer to get accurate sample readings by checking
+  what target hardware is being used and adjust accordingly.
+  You may see a "warning" come up in red during compilation
+  if a hardware timer is not being used.
 */
 #include <PulseSensorPlayground.h>
 
 
 /*
-   The format of our output.
+  The format of our output.
 
-   Set this to PROCESSING_VISUALIZER if you're going to run
+  Set this to PROCESSING_VISUALIZER if you're going to run
     the multi-sensor Processing Visualizer Sketch.
     See https://github.com/WorldFamousElectronics/PulseSensorAmped_2_Sensors
 
-   Set this to SERIAL_PLOTTER if you're going to run
+  Set this to SERIAL_PLOTTER if you're going to run
     the Arduino IDE's Serial Plotter.
 */
 const int OUTPUT_TYPE = PROCESSING_VISUALIZER;
 
 /*
-   Number of PulseSensor devices we're reading from.
+  Number of PulseSensor devices we're reading from.
 */
 const int PULSE_SENSOR_COUNT = 2;
 
 /*
-   Pinout:
-     PULSE_INPUT = Analog Input. Connected to the pulse sensor
+  Pinout:
+    PULSE_INPUT = Analog Input. Connected to the pulse sensor
       purple (signal) wire. Ends with index number.
-     PULSE_BLINK = digital Output. Connected to an LED (and 1K series resistor)
+    PULSE_BLINK = digital Output. Connected to an LED (and 1K series resistor)
       that will flash on each detected pulse. Ends with index number.
-     PULSE_FADE = digital Output. PWM pin onnected to an LED (and 1K series resistor)
+    PULSE_FADE = digital Output. PWM pin onnected to an LED (and 1K series resistor)
       that will smoothly fade with each pulse. Ends with index number.
       NOTE: PULSE_FADE must be a pin that supports PWM. Do not use
       pin 9 or 10, because those pins' PWM interferes with the sample timer. Ends with index number.
-     THRESHOLD should be set higher than the PulseSensor signal idles
+    THRESHOLD should be set higher than the PulseSensor signal idles
       at when there is nothing touching it. The expected idle value
       should be 512, which is 1/2 of the ADC range. To check the idle value
       open a serial monitor and make note of the PulseSensor signal values
@@ -79,7 +79,7 @@ const int PULSE_SENSOR_COUNT = 2;
 const int PULSE_INPUT0 = A0;
 const int PULSE_BLINK0 = LED_BUILTIN;
 const int PULSE_FADE0 = 5;
-const int THRESHOLD0 = 550;  
+const int THRESHOLD0 = 550;
 
 const int PULSE_INPUT1 = A1;
 const int PULSE_BLINK1 = 12;
@@ -87,8 +87,8 @@ const int PULSE_FADE1 = 11;
 const int THRESHOLD1 = 550;
 
 /*
-   All the PulseSensor Playground functions.
-   We tell it how many PulseSensors we're using.
+  All the PulseSensor Playground functions.
+  We tell it how many PulseSensors we're using.
 */
 PulseSensorPlayground pulseSensor(PULSE_SENSOR_COUNT);
 
@@ -101,14 +101,14 @@ int PTT;
 
 void setup() {
   /*
-     Use 250000 baud because that's what the Processing Sketch expects to read,
-     and because that speed provides about 25 bytes per millisecond,
-     or 50 characters per PulseSensor sample period of 2 milliseconds.
+    Use 250000 baud because that's what the Processing Sketch expects to read,
+    and because that speed provides about 25 bytes per millisecond,
+    or 50 characters per PulseSensor sample period of 2 milliseconds.
 
-     If we used a slower baud rate, we'd likely write bytes faster than
-     they can be transmitted, which would mess up the timing
-     of readSensor() calls, which would make the pulse measurement
-     not work properly.
+    If we used a slower baud rate, we'd likely write bytes faster than
+    they can be transmitted, which would mess up the timing
+    of readSensor() calls, which would make the pulse measurement
+    not work properly.
   */
   Serial.begin(250000);
 
@@ -153,64 +153,63 @@ void setup() {
 
 void loop() {
   /*
-     See if a sample is ready from the PulseSensor.
+    See if a sample is ready from the PulseSensor.
 
-     If USE_HARDWARE_TIMER is true, the PulseSensor Playground
-     will automatically read and process samples from
-     the PulseSensor.
+    If USE_HARDWARE_TIMER is true, the PulseSensor Playground
+    will automatically read and process samples from
+    the PulseSensor.
 
-     If USE_HARDWARE_TIMER is false, the call to sawNewSample()
-     will check to see how much time has passed, then read
-     and process a sample (analog voltage) from the PulseSensor.
-     Call this function often to maintain 500Hz sample rate,
-     that is every 2 milliseconds. Best not to have any delay() 
-     functions in the loop when using a software timer.
+    If USE_HARDWARE_TIMER is false, the call to sawNewSample()
+    will check to see how much time has passed, then read
+    and process a sample (analog voltage) from the PulseSensor.
+    Call this function often to maintain 500Hz sample rate,
+    that is every 2 milliseconds. Best not to have any delay()
+    functions in the loop when using a software timer.
 
-     Check the compatibility of your hardware at this link
-     <url>
-     and delete the unused code portions in your saved copy, if you like.
+    Check the compatibility of your hardware at this link
+    <url>
+    and delete the unused code portions in your saved copy, if you like.
   */
-if(pulseSensor.UsingHardwareTimer){
-  /*
-     Wait a bit.
-     We don't output every sample, because our baud rate
-     won't support that much I/O.
-  */
-  delay(20); 
-  // write the latest sample to Serial.
-  pulseSensor.outputSample();
-} else {
-/*
-    When using a software timer, we have to check to see if it is time
-    to acquire another sample. A call to sawNewSample will do that.
-*/
-  if (pulseSensor.sawNewSample()) {
+  if (pulseSensor.UsingHardwareTimer) {
     /*
+      Wait a bit.
+      We don't output every sample, because our baud rate
+      won't support that much I/O.
+    */
+    delay(20);
+    // write the latest sample to Serial.
+    pulseSensor.outputSample();
+  } else {
+    /*
+      When using a software timer, we have to check to see if it is time
+      to acquire another sample. A call to sawNewSample will do that.
+    */
+    if (pulseSensor.sawNewSample()) {
+      /*
         Every 20 milliseconds, send the latest Sample.
         We don't print every sample, because our baud rate
         won't support that much I/O.
-    */
-    if ((pulseSensor.samplesUntilReport--) == 0) {
-      pulseSensor.samplesUntilReport = SAMPLES_PER_SERIAL_SAMPLE;
-      pulseSensor.outputSample();
+      */
+      if ((pulseSensor.samplesUntilReport--) == 0) {
+        pulseSensor.samplesUntilReport = SAMPLES_PER_SERIAL_SAMPLE;
+        pulseSensor.outputSample();
+      }
     }
   }
-}
   /*
-     If a beat has happened on a given PulseSensor
-     since we last checked, write the per-beat information
-     about that PulseSensor to Serial.
+    If a beat has happened on a given PulseSensor
+    since we last checked, write the per-beat information
+    about that PulseSensor to Serial.
   */
   for (int i = 0; i < PULSE_SENSOR_COUNT; ++i) {
     if (pulseSensor.sawStartOfBeat(i)) {
       pulseSensor.outputBeat(i);
 
       lastBeatSampleNumber[i] = pulseSensor.getLastBeatTime(i);
-      if(i == 1){
+      if (i == 1) {
         PTT = lastBeatSampleNumber[1] - lastBeatSampleNumber[0];
-        pulseSensor.outputToSerial('|',PTT);
+        pulseSensor.outputToSerial('|', PTT);
       }
     }
   }
-
 }

--- a/examples/PulseSensor_Servo_Motor/PulseSensor_Servo_Motor.ino
+++ b/examples/PulseSensor_Servo_Motor/PulseSensor_Servo_Motor.ino
@@ -77,7 +77,7 @@ const int OUTPUT_TYPE = SERIAL_PLOTTER;
 const int PULSE_INPUT = A0;
 const int PULSE_BLINK = LED_BUILTIN;
 const int PULSE_FADE = 5;
-const int THRESHOLD = 550;   // Adjust this number to avoid noise when idle
+const int THRESHOLD = 550;  // Adjust this number to avoid noise when idle
 
 /*
    All the PulseSensor Playground functions.
@@ -127,7 +127,7 @@ void setup() {
        If your Sketch hangs here, try changing USE_ARDUINO_INTERRUPTS to false.
        which doesn't use interrupts.
     */
-    for(;;) {
+    for (;;) {
       // Flash the led to show things didn't work.
       digitalWrite(PULSE_BLINK, LOW);
       delay(50);
@@ -139,44 +139,44 @@ void setup() {
 
 void loop() {
   /*
-     See if a sample is ready from the PulseSensor.
+    See if a sample is ready from the PulseSensor.
 
-     If USE_HARDWARE_TIMER is true, the PulseSensor Playground
-     will automatically read and process samples from
-     the PulseSensor.
+    If USE_HARDWARE_TIMER is true, the PulseSensor Playground
+    will automatically read and process samples from
+    the PulseSensor.
 
-     If USE_HARDWARE_TIMER is false, the call to sawNewSample()
-     will check to see how much time has passed, then read
-     and process a sample (analog voltage) from the PulseSensor.
-     Call this function often to maintain 500Hz sample rate,
-     that is every 2 milliseconds. Best not to have any delay() 
-     functions in the loop when using a software timer.
+    If USE_HARDWARE_TIMER is false, the call to sawNewSample()
+    will check to see how much time has passed, then read
+    and process a sample (analog voltage) from the PulseSensor.
+    Call this function often to maintain 500Hz sample rate,
+    that is every 2 milliseconds. Best not to have any delay()
+    functions in the loop when using a software timer.
 
-     Check the compatibility of your hardware at this link
-     <url>
-     and delete the unused code portions in your saved copy, if you like.
+    Check the compatibility of your hardware at this link
+    <url>
+    and delete the unused code portions in your saved copy, if you like.
   */
-  if(pulseSensor.UsingHardwareTimer){
+  if (pulseSensor.UsingHardwareTimer) {
     /*
-       Wait a bit.
-       We don't output every sample, because our baud rate
-       won't support that much I/O.
+      Wait a bit.
+      We don't output every sample, because our baud rate
+      won't support that much I/O.
     */
-    delay(20); 
+    delay(20);
     // write the latest sample to Serial.
     pulseSensor.outputSample();
     // write the latest analog value to the heart servo
     moveServo(pulseSensor.getLatestSample());
   } else {
-  /*
+    /*
       When using a software timer, we have to check to see if it is time
       to acquire another sample. A call to sawNewSample will do that.
-  */
+    */
     if (pulseSensor.sawNewSample()) {
       /*
-          Every 20 milliseconds, send the latest Sample.
-          We don't print every sample, because our baud rate
-          won't support that much I/O.
+        Every 20 milliseconds, send the latest Sample.
+        We don't print every sample, because our baud rate
+        won't support that much I/O.
       */
       if (--pulseSensor.samplesUntilReport == (byte) 0) {
         pulseSensor.samplesUntilReport = SAMPLES_PER_SERIAL_SAMPLE;
@@ -186,7 +186,6 @@ void loop() {
       }
     }
   }
-  
 }
 
 
@@ -196,7 +195,7 @@ void loop() {
   Servo = 0 <> 180
   Modify as you see fit!
 */
-void moveServo(int value){
-  pos = map(value,0,1023,0,180);
+void moveServo(int value) {
+  pos = map(value, 0, 1023, 0, 180);
   heart.write(pos);
 }

--- a/examples/PulseSensor_Speaker/PulseSensor_Speaker.ino
+++ b/examples/PulseSensor_Speaker/PulseSensor_Speaker.ino
@@ -28,38 +28,38 @@
 */
 
 /*
-   Include the PulseSensor Playground library to get all the good stuff!
-   The PulseSensor Playground library will decide whether to use
-   a hardware timer to get accurate sample readings by checking
-   what target hardware is being used and adjust accordingly.
-   You may see a "warning" come up in red during compilation
-   if a hardware timer is not being used.
+  Include the PulseSensor Playground library to get all the good stuff!
+  The PulseSensor Playground library will decide whether to use
+  a hardware timer to get accurate sample readings by checking
+  what target hardware is being used and adjust accordingly.
+  You may see a "warning" come up in red during compilation
+  if a hardware timer is not being used.
 */
 #include <PulseSensorPlayground.h>
 
 /*
-   The format of our output.
+  The format of our output.
 
-   Set this to PROCESSING_VISUALIZER if you're going to run
+  Set this to PROCESSING_VISUALIZER if you're going to run
     the Processing Visualizer Sketch.
     See https://github.com/WorldFamousElectronics/PulseSensor_Amped_Processing_Visualizer
 
-   Set this to SERIAL_PLOTTER if you're going to run
+  Set this to SERIAL_PLOTTER if you're going to run
     the Arduino IDE's Serial Plotter.
 */
 const int OUTPUT_TYPE = SERIAL_PLOTTER;
 
 /*
-   Pinout:
-     PULSE_INPUT = Analog Input. Connected to the pulse sensor
+  Pinout:
+    PULSE_INPUT = Analog Input. Connected to the pulse sensor
       purple (signal) wire.
-     PULSE_BLINK = digital Output. Connected to an LED (and 1K series resistor)
+    PULSE_BLINK = digital Output. Connected to an LED (and 1K series resistor)
       that will flash on each detected pulse.
-     PULSE_FADE = digital Output. PWM pin onnected to an LED (and 1K series resistor)
+    PULSE_FADE = digital Output. PWM pin onnected to an LED (and 1K series resistor)
       that will smoothly fade with each pulse.
       NOTE: PULSE_FADE must be a pin that supports PWM. Do not use
       pin 9 or 10, because those pins' PWM interferes with the sample timer.
-     THRESHOLD should be set higher than the PulseSensor signal idles
+    THRESHOLD should be set higher than the PulseSensor signal idles
       at when there is nothing touching it. The expected idle value
       should be 512, which is 1/2 of the ADC range. To check the idle value
       open a serial monitor and make note of the PulseSensor signal values
@@ -72,10 +72,10 @@ const int OUTPUT_TYPE = SERIAL_PLOTTER;
 const int PULSE_INPUT = A0;
 const int PULSE_BLINK = LED_BUILTIN;
 const int PULSE_FADE = 5;
-const int THRESHOLD = 550;   // Adjust this number to avoid noise when idle
+const int THRESHOLD = 550;  // Adjust this number to avoid noise when idle
 
 /*
-   All the PulseSensor Playground functions.
+  All the PulseSensor Playground functions.
 */
 PulseSensorPlayground pulseSensor;
 
@@ -88,18 +88,18 @@ PulseSensorPlayground pulseSensor;
         Follow this tutorial:
         https://pulsesensor.com/pages/pulse-sensor-speaker-tutorial
 */
-const int SPEAKER_PIN = 3;    // speaker pin must have PWM capability!
+const int SPEAKER_PIN = 3;  // speaker pin must have PWM capability!
 
 
 void setup() {
   /*
-     Use 115200 baud because that's what the Processing Sketch expects to read,
-     and because that speed provides about 11 bytes per millisecond.
+    Use 115200 baud because that's what the Processing Sketch expects to read,
+    and because that speed provides about 11 bytes per millisecond.
 
-     If we used a slower baud rate, we'd likely write bytes faster than
-     they can be transmitted, which would mess up the timing
-     of readSensor() calls, which would make the pulse measurement
-     not work properly.
+    If we used a slower baud rate, we'd likely write bytes faster than
+    they can be transmitted, which would mess up the timing
+    of readSensor() calls, which would make the pulse measurement
+    not work properly.
   */
   Serial.begin(115200);
 
@@ -116,14 +116,14 @@ void setup() {
   // Now that everything is ready, start reading the PulseSensor signal.
   if (!pulseSensor.begin()) {
     /*
-       PulseSensor initialization failed,
-       likely because our particular Arduino platform interrupts
-       aren't supported yet.
+      PulseSensor initialization failed,
+      likely because our particular Arduino platform interrupts
+      aren't supported yet.
 
-       If your Sketch hangs here, try changing USE_ARDUINO_INTERRUPTS to false.
-       which doesn't use interrupts.
+      If your Sketch hangs here, try changing USE_ARDUINO_INTERRUPTS to false.
+      which doesn't use interrupts.
     */
-    for(;;) {
+    for (;;) {
       // Flash the led to show things didn't work.
       digitalWrite(PULSE_BLINK, LOW);
       delay(50);
@@ -135,42 +135,42 @@ void setup() {
 
 void loop() {
   /*
-     See if a sample is ready from the PulseSensor.
+    See if a sample is ready from the PulseSensor.
 
-     If USE_HARDWARE_TIMER is true, the PulseSensor Playground
-     will automatically read and process samples from
-     the PulseSensor.
+    If USE_HARDWARE_TIMER is true, the PulseSensor Playground
+    will automatically read and process samples from
+    the PulseSensor.
 
-     If USE_HARDWARE_TIMER is false, the call to sawNewSample()
-     will check to see how much time has passed, then read
-     and process a sample (analog voltage) from the PulseSensor.
-     Call this function often to maintain 500Hz sample rate,
-     that is every 2 milliseconds. Best not to have any delay() 
-     functions in the loop when using a software timer.
+    If USE_HARDWARE_TIMER is false, the call to sawNewSample()
+    will check to see how much time has passed, then read
+    and process a sample (analog voltage) from the PulseSensor.
+    Call this function often to maintain 500Hz sample rate,
+    that is every 2 milliseconds. Best not to have any delay()
+    functions in the loop when using a software timer.
 
-     Check the compatibility of your hardware at this link
-     <url>
-     and delete the unused code portions in your saved copy, if you like.
+    Check the compatibility of your hardware at this link
+    <url>
+    and delete the unused code portions in your saved copy, if you like.
   */
-  if(pulseSensor.UsingHardwareTimer){
+  if (pulseSensor.UsingHardwareTimer) {
     /*
-       Wait a bit.
-       We don't output every sample, because our baud rate
-       won't support that much I/O.
+      Wait a bit.
+      We don't output every sample, because our baud rate
+      won't support that much I/O.
     */
-    delay(20); 
+    delay(20);
     // write the latest sample to Serial.
     pulseSensor.outputSample();
   } else {
-  /*
+    /*
       When using a software timer, we have to check to see if it is time
       to acquire another sample. A call to sawNewSample will do that.
-  */
+    */
     if (pulseSensor.sawNewSample()) {
       /*
-          Every 20 milliseconds, send the latest Sample.
-          We don't print every sample, because our baud rate
-          won't support that much I/O.
+        Every 20 milliseconds, send the latest Sample.
+        We don't print every sample, because our baud rate
+        won't support that much I/O.
       */
       if ((pulseSensor.samplesUntilReport--) == 0) {
         pulseSensor.samplesUntilReport = SAMPLES_PER_SERIAL_SAMPLE;
@@ -180,31 +180,30 @@ void loop() {
   }
 
   /*
-     If a beat has happened since we last checked,
-     write the per-beat information to Serial.
-     write a frequency to the PIN_SPEAKER
-     NOTE: Do not set the optional duration of tone! That is blocking!
+    If a beat has happened since we last checked,
+    write the per-beat information to Serial.
+    write a frequency to the PIN_SPEAKER
+    NOTE: Do not set the optional duration of tone! That is blocking!
    */
   if (pulseSensor.sawStartOfBeat()) {
     pulseSensor.outputBeat();
-    heartBeep(SPEAKER_PIN,true);
+    heartBeep(SPEAKER_PIN, true);
   }
 
   /*
     The Pulse variable is true only for a short time after the heartbeat is detected
     Use this to time the duration of the beep
   */
-  if(pulseSensor.isInsideBeat() == false){
-    heartBeep(SPEAKER_PIN,false);
+  if (pulseSensor.isInsideBeat() == false) {
+    heartBeep(SPEAKER_PIN, false);
   }
-
 }
 /*
   heartBeep(a pin, to beep or not to beep)
     The pin parameter needs to be a PWM capable pin.
     The beep parameter turns on or off the sound.
-    
-  This function will reliably output a clean tone (500Hz on AVR, sounds about Bb). 
+
+  This function will reliably output a clean tone (500Hz on AVR, sounds about Bb).
   You can try the tone() function that comes in the Arduino core if you want a different note, but it will be noisy.
     The Arduino tone() function starts up a hardware timer at a specific freqeuency, and initializes an interrupt.
     The problem with using tone() is that the interrupt needs to be called in order to toggle the pin at frequency.
@@ -212,12 +211,12 @@ void loop() {
     The collision causes noise in the tone(), and likely makes any BPM values incorrect!
     The arduino core needs to be updated so that the tone library operates 'hands free' like the PWM library.
     Or, the PWM library needs to be updated to accept a frequency parameter to ensure a clean(er) note.
-    There are some architectures upon which the Tone library might work: nRF52? ESP32? 
+    There are some architectures upon which the Tone library might work: nRF52? ESP32?
 */
-void heartBeep(int pin, bool beep){
-  if(beep){
-    analogWrite(pin,127);
+void heartBeep(int pin, bool beep) {
+  if (beep) {
+    analogWrite(pin, 127);
   } else {
-    analogWrite(pin,0);
+    analogWrite(pin, 0);
   }
 }

--- a/examples/PulseSensor_UNO_R4_WiFi_LEDmatrix_Heartbeat/PulseSensor_UNO_R4_WiFi_LEDmatrix_Heartbeat.ino
+++ b/examples/PulseSensor_UNO_R4_WiFi_LEDmatrix_Heartbeat/PulseSensor_UNO_R4_WiFi_LEDmatrix_Heartbeat.ino
@@ -23,38 +23,38 @@
 */
 
 /*
-   Include the PulseSensor Playground library to get all the good stuff!
-   The PulseSensor Playground library will decide whether to use
-   a hardware timer to get accurate sample readings by checking
-   what target hardware is being used and adjust accordingly.
-   You will see a warning during compilation that notes if 
-   a hardware timer is being used or not.
+  Include the PulseSensor Playground library to get all the good stuff!
+  The PulseSensor Playground library will decide whether to use
+  a hardware timer to get accurate sample readings by checking
+  what target hardware is being used and adjust accordingly.
+  You will see a warning during compilation that notes if
+  a hardware timer is being used or not.
 */
 #include <PulseSensorPlayground.h>
 
 /*
-   The format of our output.
+  The format of our output.
 
-   Set this to PROCESSING_VISUALIZER if you're going to run
+  Set this to PROCESSING_VISUALIZER if you're going to run
     the Processing Visualizer Sketch.
     See https://github.com/WorldFamousElectronics/PulseSensor_Amped_Processing_Visualizer
 
-   Set this to SERIAL_PLOTTER if you're going to run
+  Set this to SERIAL_PLOTTER if you're going to run
     the Arduino IDE's Serial Plotter.
 */
 const int OUTPUT_TYPE = SERIAL_PLOTTER;
 
 /*
-   Pinout:
-     PULSE_INPUT = Analog Input. Connected to the pulse sensor
+  Pinout:
+    PULSE_INPUT = Analog Input. Connected to the pulse sensor
       purple (signal) wire.
-     PULSE_BLINK = digital Output. Connected to an LED (and 1K series resistor)
+    PULSE_BLINK = digital Output. Connected to an LED (and 1K series resistor)
       that will flash on each detected pulse.
-     PULSE_FADE = digital Output. PWM pin onnected to an LED (and 1K series resistor)
+    PULSE_FADE = digital Output. PWM pin onnected to an LED (and 1K series resistor)
       that will smoothly fade with each pulse.
       NOTE: PULSE_FADE must be a pin that supports PWM. Do not use
       pin 9 or 10, because those pins' PWM interferes with the sample timer.
-     THRESHOLD should be set higher than the PulseSensor signal idles
+    THRESHOLD should be set higher than the PulseSensor signal idles
       at when there is nothing touching it. The expected idle value
       should be 512, which is 1/2 of the ADC range. To check the idle value
       open a serial monitor and make note of the PulseSensor signal values
@@ -67,48 +67,46 @@ const int OUTPUT_TYPE = SERIAL_PLOTTER;
 const int PULSE_INPUT = A0;
 const int PULSE_BLINK = LED_BUILTIN;
 const int PULSE_FADE = 5;
-const int THRESHOLD = 550;   // Adjust this number to avoid noise when idle
+const int THRESHOLD = 550;  // Adjust this number to avoid noise when idle
 
 /*
-   All the PulseSensor Playground functions.
+  All the PulseSensor Playground functions.
 */
 PulseSensorPlayground pulseSensor;
 
 /*
-    Library and variables used to draw the heart animation
-    The Arduino heart icon will pulse with your heartbeat!
+  Library and variables used to draw the heart animation
+  The Arduino heart icon will pulse with your heartbeat!
 */
 #include "Arduino_LED_Matrix.h"
 ArduinoLEDMatrix beatingHeart;
 byte heart[8][12] = {
-  { 0,0,0,0,0,0,0,0,0,0,0,0 },
-  { 0,0,0,0,0,0,0,0,0,0,0,0 },
-  { 0,0,0,0,0,1,0,1,0,0,0,0 },
-  { 0,0,0,0,1,0,1,0,1,0,0,0 },
-  { 0,0,0,0,1,0,0,0,1,0,0,0 },
-  { 0,0,0,0,0,1,0,1,0,0,0,0 },
-  { 0,0,0,0,0,0,1,0,0,0,0,0 },
-  { 0,0,0,0,0,0,0,0,0,0,0,0 }
-};
+  {0,0,0,0,0,0,0,0,0,0,0,0},
+  {0,0,0,0,0,0,0,0,0,0,0,0},
+  {0,0,0,0,0,1,0,1,0,0,0,0},
+  {0,0,0,0,1,0,1,0,1,0,0,0},
+  {0,0,0,0,1,0,0,0,1,0,0,0},
+  {0,0,0,0,0,1,0,1,0,0,0,0},
+  {0,0,0,0,0,0,1,0,0,0,0,0},
+  {0,0,0,0,0,0,0,0,0,0,0,0}};
 byte heartPulse[8][12] = {
-  { 0,0,0,0,0,0,0,0,0,0,0,0 },
-  { 0,0,0,0,1,1,0,1,1,0,0,0 },
-  { 0,0,0,1,0,0,1,0,0,1,0,0 },
-  { 0,0,0,1,0,0,0,0,0,1,0,0 },
-  { 0,0,0,0,1,0,0,0,1,0,0,0 },
-  { 0,0,0,0,0,1,0,1,0,0,0,0 },
-  { 0,0,0,0,0,0,1,0,0,0,0,0 },
-  { 0,0,0,0,0,0,0,0,0,0,0,0 }
-};
+  {0,0,0,0,0,0,0,0,0,0,0,0},
+  {0,0,0,0,1,1,0,1,1,0,0,0},
+  {0,0,0,1,0,0,1,0,0,1,0,0},
+  {0,0,0,1,0,0,0,0,0,1,0,0},
+  {0,0,0,0,1,0,0,0,1,0,0,0},
+  {0,0,0,0,0,1,0,1,0,0,0,0},
+  {0,0,0,0,0,0,1,0,0,0,0,0},
+  {0,0,0,0,0,0,0,0,0,0,0,0}};
 
 void setup() {
   /*
-     Use 115200 baud because that's what the Processing Sketch expects to read,
-     and because that speed provides about 11 bytes per millisecond.
+    Use 115200 baud because that's what the Processing Sketch expects to read,
+    and because that speed provides about 11 bytes per millisecond.
 
-     If we used a slower baud rate, we'd likely write bytes faster than
-     they can be transmitted, which would mess up the sample reading
-     calls, which would make the pulse measurement not work properly.
+    If we used a slower baud rate, we'd likely write bytes faster than
+    they can be transmitted, which would mess up the sample reading
+    calls, which would make the pulse measurement not work properly.
   */
   Serial.begin(115200);
 
@@ -125,17 +123,18 @@ void setup() {
   // Now that everything is ready, start reading the PulseSensor signal.
   if (!pulseSensor.begin()) {
     /*
-       PulseSensor initialization failed,
-       likely because our particular Arduino platform interrupts
-       aren't supported yet.
+      PulseSensor initialization failed,
+      likely because our particular Arduino platform interrupts
+      aren't supported yet.
 
-       If your Sketch hangs here, try PulseSensor_BPM_Alternative.ino,
-       which doesn't use interrupts.
+      If your Sketch hangs here, try PulseSensor_BPM_Alternative.ino,
+      which doesn't use interrupts.
     */
-    for(;;) {
+    for (;;) {
       // Flash the led to show things didn't work.
       digitalWrite(PULSE_BLINK, LOW);
-      delay(50); Serial.println('!');
+      delay(50);
+      Serial.println('!');
       digitalWrite(PULSE_BLINK, HIGH);
       delay(50);
     }
@@ -147,31 +146,29 @@ void setup() {
 
 void loop() {
   /*
-     Wait a bit.
-     We don't output every sample, because our baud rate
-     won't support that much I/O.
+    Wait a bit.
+    We don't output every sample, because our baud rate
+    won't support that much I/O.
   */
   delay(20);
 
   // write the latest sample to Serial.
- pulseSensor.outputSample();
+  pulseSensor.outputSample();
 
-/*
+  /*
     The method isInsideBeat returns true when the pulse wave is above THRESHOLD.
     The timing makes a nice heart pulse along with your heartbeat.
-*/
-  if(pulseSensor.isInsideBeat()){
+  */
+  if (pulseSensor.isInsideBeat()) {
     beatingHeart.renderBitmap(heartPulse, 8, 12);
   } else {
     beatingHeart.renderBitmap(heart, 8, 12);
   }
   /*
-     If a beat has happened since we last checked,
-     write the per-beat information to Serial.
-   */
+    If a beat has happened since we last checked,
+    write the per-beat information to Serial.
+  */
   if (pulseSensor.sawStartOfBeat()) {
-   pulseSensor.outputBeat();
+    pulseSensor.outputBeat();
   }
-
 }
-

--- a/examples/PulseSensor_UNO_R4_WiFi_LEDmatrix_Plotter/PulseSensor_UNO_R4_WiFi_LEDmatrix_Plotter.ino
+++ b/examples/PulseSensor_UNO_R4_WiFi_LEDmatrix_Plotter/PulseSensor_UNO_R4_WiFi_LEDmatrix_Plotter.ino
@@ -24,38 +24,38 @@
 */
 
 /*
-   Include the PulseSensor Playground library to get all the good stuff!
-   The PulseSensor Playground library will decide whether to use
-   a hardware timer to get accurate sample readings by checking
-   what target hardware is being used and adjust accordingly.
-   You will see a warning during compilation that notes if 
-   a hardware timer is being used or not.
+  Include the PulseSensor Playground library to get all the good stuff!
+  The PulseSensor Playground library will decide whether to use
+  a hardware timer to get accurate sample readings by checking
+  what target hardware is being used and adjust accordingly.
+  You will see a warning during compilation that notes if
+  a hardware timer is being used or not.
 */
 #include <PulseSensorPlayground.h>
 
 /*
-   The format of our output.
+  The format of our output.
 
-   Set this to PROCESSING_VISUALIZER if you're going to run
+  Set this to PROCESSING_VISUALIZER if you're going to run
     the Processing Visualizer Sketch.
     See https://github.com/WorldFamousElectronics/PulseSensor_Amped_Processing_Visualizer
 
-   Set this to SERIAL_PLOTTER if you're going to run
+  Set this to SERIAL_PLOTTER if you're going to run
     the Arduino IDE's Serial Plotter.
 */
 const int OUTPUT_TYPE = SERIAL_PLOTTER;
 
 /*
-   Pinout:
-     PULSE_INPUT = Analog Input. Connected to the pulse sensor
+  Pinout:
+    PULSE_INPUT = Analog Input. Connected to the pulse sensor
       purple (signal) wire.
-     PULSE_BLINK = digital Output. Connected to an LED (and 1K series resistor)
+    PULSE_BLINK = digital Output. Connected to an LED (and 1K series resistor)
       that will flash on each detected pulse.
-     PULSE_FADE = digital Output. PWM pin onnected to an LED (and 1K series resistor)
+    PULSE_FADE = digital Output. PWM pin onnected to an LED (and 1K series resistor)
       that will smoothly fade with each pulse.
       NOTE: PULSE_FADE must be a pin that supports PWM. Do not use
       pin 9 or 10, because those pins' PWM interferes with the sample timer.
-     THRESHOLD should be set higher than the PulseSensor signal idles
+    THRESHOLD should be set higher than the PulseSensor signal idles
       at when there is nothing touching it. The expected idle value
       should be 512, which is 1/2 of the ADC range. To check the idle value
       open a serial monitor and make note of the PulseSensor signal values
@@ -68,15 +68,15 @@ const int OUTPUT_TYPE = SERIAL_PLOTTER;
 const int PULSE_INPUT = A0;
 const int PULSE_BLINK = LED_BUILTIN;
 const int PULSE_FADE = 5;
-const int THRESHOLD = 550;   // Adjust this number to avoid noise when idle
+const int THRESHOLD = 550;  // Adjust this number to avoid noise when idle
 
 /*
-   All the PulseSensor Playground functions.
+  All the PulseSensor Playground functions.
 */
 PulseSensorPlayground pulseSensor;
 
 /*
-    library and variables used to plot on the LED matrix
+  library and variables used to plot on the LED matrix
 */
 #include "Arduino_LED_Matrix.h"
 ArduinoLEDMatrix plotter;
@@ -85,24 +85,24 @@ int maxY = 7;
 int minX = 0;
 int minY = 0;
 int pulseSignal;
-byte frame[8][12] = { // frame array is [y][x]
-  { 0,0,0,0,0,0,0,0,0,0,0,0 },
-  { 0,0,0,0,0,0,0,0,0,0,0,0 },
-  { 0,0,0,0,0,0,0,0,0,0,0,0 },
-  { 0,0,0,0,0,0,0,0,0,0,0,0 },
-  { 0,0,0,0,0,0,0,0,0,0,0,0 },
-  { 0,0,0,0,0,0,0,0,0,0,0,0 },
-  { 0,0,0,0,0,0,0,0,0,0,0,0 },
-  { 0,0,0,0,0,0,0,0,0,0,0,0 }
-};
+byte frame[8][12] = {  // frame array is [y][x]
+  {0,0,0,0,0,0,0,0,0,0,0,0},
+  {0,0,0,0,0,0,0,0,0,0,0,0},
+  {0,0,0,0,0,0,0,0,0,0,0,0},
+  {0,0,0,0,0,0,0,0,0,0,0,0},
+  {0,0,0,0,0,0,0,0,0,0,0,0},
+  {0,0,0,0,0,0,0,0,0,0,0,0},
+  {0,0,0,0,0,0,0,0,0,0,0,0},
+  {0,0,0,0,0,0,0,0,0,0,0,0}};
+
 void setup() {
   /*
-     Use 115200 baud because that's what the Processing Sketch expects to read,
-     and because that speed provides about 11 bytes per millisecond.
+    Use 115200 baud because that's what the Processing Sketch expects to read,
+    and because that speed provides about 11 bytes per millisecond.
 
-     If we used a slower baud rate, we'd likely write bytes faster than
-     they can be transmitted, which would mess up the sample reading
-     calls, which would make the pulse measurement not work properly.
+    If we used a slower baud rate, we'd likely write bytes faster than
+    they can be transmitted, which would mess up the sample reading
+    calls, which would make the pulse measurement not work properly.
   */
   Serial.begin(115200);
 
@@ -119,45 +119,46 @@ void setup() {
   // Now that everything is ready, start reading the PulseSensor signal.
   if (!pulseSensor.begin()) {
     /*
-       PulseSensor initialization failed,
-       likely because our particular Arduino platform interrupts
-       aren't supported yet.
+      PulseSensor initialization failed,
+      likely because our particular Arduino platform interrupts
+      aren't supported yet.
 
-       If your Sketch hangs here, try PulseSensor_BPM_Alternative.ino,
-       which doesn't use interrupts.
+      If your Sketch hangs here, try PulseSensor_BPM_Alternative.ino,
+      which doesn't use interrupts.
     */
-    for(;;) {
+    for (;;) {
       // Flash the led to show things didn't work.
       digitalWrite(PULSE_BLINK, LOW);
-      delay(50); Serial.println('!');
+      delay(50);
+      Serial.println('!');
       digitalWrite(PULSE_BLINK, HIGH);
       delay(50);
     }
   }
-  
+
   // start up the LED matrix so we can control it.
   plotter.begin();
 }
 
 void loop() {
   /*
-     Wait a bit.
-     We don't output every sample, because our baud rate
-     won't support that much I/O.
+    Wait a bit.
+    We don't output every sample, because our baud rate
+    won't support that much I/O.
   */
   delay(20);
 
   // write the latest sample to Serial.
- pulseSensor.outputSample();
+  pulseSensor.outputSample();
 
-/*
+  /*
     Get the latest PulseSensor signal value and scale it to fit the LED matrix.
     advanceLEDplotter shifts the data history to the left.
-*/
-  pulseSignal = pulseSensor.getLatestSample(); // copy the latest sample value
-  pulseSignal = 1023 - pulseSignal; // invert for matrix disply to show with X axis along power and analog pins
-  pulseSignal = pulseSignal/128;  // scale to the LED matrix height
-  pulseSignal = constrain(pulseSignal, minY, maxY); // limit the singal so it won't get out of the frame
+  */
+  pulseSignal = pulseSensor.getLatestSample();  // copy the latest sample value
+  pulseSignal = 1023 - pulseSignal;  // invert for matrix disply to show with X axis along power and analog pins
+  pulseSignal = pulseSignal / 128;   // scale to the LED matrix height
+  pulseSignal = constrain(pulseSignal, minY, maxY);  // limit the singal so it won't get out of the frame
   advanceLEDplotter();
   plotter.renderBitmap(frame, 8, 12);
 
@@ -166,9 +167,8 @@ void loop() {
      write the per-beat information to Serial.
    */
   if (pulseSensor.sawStartOfBeat()) {
-   pulseSensor.outputBeat();
+    pulseSensor.outputBeat();
   }
-
 }
 
 
@@ -176,10 +176,10 @@ void loop() {
   New PulseSensor data comes in on the right of the plotter.
   The 'right' is the matrix edge along the Qwiic/STEMMA connector edge of the board.
 */
-void advanceLEDplotter(){
-  for(int y=0; y<=maxY; y++){
-    for(int x=0; x<=maxX-1; x++){
-      if(frame[y][x+1] == 1){
+void advanceLEDplotter() {
+  for (int y = 0; y <= maxY; y++) {
+    for (int x = 0; x <= maxX - 1; x++) {
+      if (frame[y][x+1] == 1) {
         frame[y][x] = 1;
         frame[y][x+1] = 0;
       } else {

--- a/examples/PulseSensor_nRF52_Heartrate_Monitor_Service/PulseSensor_nRF52_Heartrate_Monitor_Service.ino
+++ b/examples/PulseSensor_nRF52_Heartrate_Monitor_Service/PulseSensor_nRF52_Heartrate_Monitor_Service.ino
@@ -1,8 +1,8 @@
 /*
-   This code is written to target the following hardrware:
+    This code is written to target the following hardrware:
       Adafruit nRF52 boards
       Seeed Studio nRF52 boards (NO EMBED)
-   Embed board architecture will be supported in the future.
+    Embed board architecture will be supported in the future.
 
     Check out the PulseSensor Playground Tools for explaination
     of all user functions and directives.
@@ -20,57 +20,57 @@
 */
 
 /*
-    Include the Adafruit bluefruit library
-    The nRF52 will play the role of Server
-    The phone or tablet will play the role of Client
+  Include the Adafruit bluefruit library
+  The nRF52 will play the role of Server
+  The phone or tablet will play the role of Client
 */
 #include <bluefruit.h>
 
 /*
-    Heartrate Monitor Service 
-    These are defined in the bluefruit library
-    The service exposes characteristics that allow for different data
-    to be sent by the Server as heartrate specific information. 
-    BLEService is defined as heartrate monitor service
-    The heartrate measurement characteristing (hrmc) is used to send the BPM
-    The body sensor location (bslc) is used to send the PulseSensor location
-    the byte variable bpm will be used to transmit PulseSensor heartrate to the client
+  Heartrate Monitor Service
+  These are defined in the bluefruit library
+  The service exposes characteristics that allow for different data
+  to be sent by the Server as heartrate specific information.
+  BLEService is defined as heartrate monitor service
+  The heartrate measurement characteristing (hrmc) is used to send the BPM
+  The body sensor location (bslc) is used to send the PulseSensor location
+  the byte variable bpm will be used to transmit PulseSensor heartrate to the client
 */
 BLEService        hrms = BLEService(UUID16_SVC_HEART_RATE);
 BLECharacteristic hrmc = BLECharacteristic(UUID16_CHR_HEART_RATE_MEASUREMENT);
 BLECharacteristic bslc = BLECharacteristic(UUID16_CHR_BODY_SENSOR_LOCATION);
-uint8_t  bpm = 0;
+uint8_t bpm = 0;
 
 /*
-    Device Information Service 
-    This service allows us to add characteristics like 
-    > Manufacturer
-    > Model
-    > Serial Number
-    > Hardware Version
-    > Frimware Version
-    > etc.
+  Device Information Service
+  This service allows us to add characteristics like
+  > Manufacturer
+  > Model
+  > Serial Number
+  > Hardware Version
+  > Frimware Version
+  > etc.
 */
-BLEDis bledis;   
+BLEDis bledis;
 
 /*
-   Include the PulseSensor Playground library to get all the good stuff!
-   The PulseSensor Playground library will decide whether to use
-   a hardware timer to get accurate sample readings by checking
-   what target hardware is being used and adjust accordingly.
-   You may see a "warning" come up in red during compilation
-   if a hardware timer is not being used.
+  Include the PulseSensor Playground library to get all the good stuff!
+  The PulseSensor Playground library will decide whether to use
+  a hardware timer to get accurate sample readings by checking
+  what target hardware is being used and adjust accordingly.
+  You may see a "warning" come up in red during compilation
+  if a hardware timer is not being used.
 */
 #include <PulseSensorPlayground.h>
 
 /*
-   The format of our output.
+  The format of our output.
 
-   Set this to PROCESSING_VISUALIZER if you're going to run
+  Set this to PROCESSING_VISUALIZER if you're going to run
     the Processing Visualizer Sketch.
     See https://github.com/WorldFamousElectronics/PulseSensor_Amped_Processing_Visualizer
 
-   Set this to SERIAL_PLOTTER if you're going to run
+  Set this to SERIAL_PLOTTER if you're going to run
     the Arduino IDE's Serial Plotter.
 */
 const int OUTPUT_TYPE = SERIAL_PLOTTER;
@@ -98,7 +98,7 @@ const int OUTPUT_TYPE = SERIAL_PLOTTER;
 const int PULSE_INPUT = A0;
 const int PULSE_BLINK = 13;
 const int PULSE_FADE = 12;
-const int THRESHOLD = 550;   // Adjust this number to avoid noise when idle
+const int THRESHOLD = 550;  // Adjust this number to avoid noise when idle
 
 /*
    All the PulseSensor Playground functions.
@@ -112,7 +112,7 @@ void setup() {
      they can be transmitted,.
   */
   Serial.begin(115200);
-  while (!Serial && millis() < 5000);
+  while (!Serial && millis() < 5000) {}
 
   // Configure the PulseSensor manager.
 
@@ -134,7 +134,7 @@ void setup() {
        If your Sketch hangs here, try PulseSensor_BPM_Alternative.ino,
        which doesn't use interrupts.
     */
-    for(;;) {
+    for (;;) {
       // Flash the led to show things didn't work.
       digitalWrite(PULSE_BLINK, LOW);
       delay(50);
@@ -143,13 +143,13 @@ void setup() {
     }
   }
 
-/*
+  /*
     Begin the Bluetooth
     Define callback routines to run on connect and disconnect
     Set Device Information Characteristic attributes
     Set up the advertising packet
     Start advertising
-*/
+  */
   Serial.println("Starting BLE");
   Bluefruit.begin();
   Bluefruit.setName("PulseSensor");
@@ -161,82 +161,83 @@ void setup() {
   startAdvertising();
   Serial.println("Advertising\nConnect via Bluetooth to PulseSensor to view BPM");
 
-} // end of setup()
+}  // end of setup()
 
 void loop() {
   /*
-     When a heartbeat happens, print the BPM to serial
-     and notify connected client of the updated BPM value
-   */
+    When a heartbeat happens, print the BPM to serial
+    and notify connected client of the updated BPM value
+  */
   if (pulseSensor.sawStartOfBeat()) {
     bpm = uint8_t(pulseSensor.getBeatsPerMinute());
-    if ( Bluefruit.connected() ) {
-        uint8_t heartRateData[2] = { 0b00000110, bpm };           // Sensor connected, BPM value
-        if (hrmc.notify(heartRateData, sizeof(heartRateData))){
-          Serial.print("Heart Rate Updated: "); 
-        } else {
-          Serial.println("error: Notify not set or not connected!");
-        }
+    if (Bluefruit.connected()) {
+      uint8_t heartRateData[2] = {0b00000110, bpm};  // Sensor connected, BPM value
+      if (hrmc.notify(heartRateData, sizeof(heartRateData))) {
+        Serial.print("Heart Rate Updated: ");
+      } else {
+        Serial.println("error: Notify not set or not connected!");
+      }
     }
-    Serial.print(bpm,DEC); Serial.println(" BPM");
+    Serial.print(bpm, DEC);
+    Serial.println(" BPM");
   }
 }
 
 /*
-    startAdvertising()
-    This function builds the packet that is sent
-    to potential Clients. This lets Clients know what kind 
-    of data they can get from us.
-    Tell the bluetooth to restart advertising on disconnect from client
-    setInterval and setFastTimeout tell the Bluetooth how often and how long
-    to advertise. Setting start(timeout) = 0 will continue to advertise until connected
+  startAdvertising()
+  This function builds the packet that is sent
+  to potential Clients. This lets Clients know what kind
+  of data they can get from us.
+  Tell the bluetooth to restart advertising on disconnect from client
+  setInterval and setFastTimeout tell the Bluetooth how often and how long
+  to advertise. Setting start(timeout) = 0 will continue to advertise until connected
 */
-void startAdvertising(void){
+void startAdvertising(void) {
   Bluefruit.Advertising.addFlags(BLE_GAP_ADV_FLAGS_LE_ONLY_GENERAL_DISC_MODE);
   Bluefruit.Advertising.addTxPower();
   Bluefruit.Advertising.addService(hrms);
   Bluefruit.Advertising.addName();
   Bluefruit.Advertising.restartOnDisconnect(true);
-  Bluefruit.Advertising.setInterval(32, 244);    // in unit of 0.625 ms
-  Bluefruit.Advertising.setFastTimeout(30);      // number of seconds in fast mode
-  Bluefruit.Advertising.start(0);                // 0 = Don't stop advertising after n seconds  
+  Bluefruit.Advertising.setInterval(32, 244);  // in unit of 0.625 ms
+  Bluefruit.Advertising.setFastTimeout(30);    // number of seconds in fast mode
+  Bluefruit.Advertising.start(0);              // 0 = Don't stop advertising after n seconds
 }
 
 /*
-    setupHeartrateMonitor()
-    This function initializes the heartrate monitor service.
-    hrms.begin() must be called before any characteristics can be set.
-    hrmc.setProperties() defines the way that we will send the data
-    hrmc.setPermission() defines the security access. First parameter is read, second is write.
-    hrmc.setFixedLen() defines how many bytes the characteristic has
-        first byte is metadata
-        second byte is heartrate
-    Now, the characteristic can begin, and once started we can write to it
-    hrmc.write() tells the characteristic to expect 8 bit values and that the PulseSensor is connected
-    The Sensor Location characteristic setup is similar.
-    After is it begun, the bslc.write() sends a byte variable to set the physical location of the PulseSensor
-        0 = OTHER
-        1 = CHEST
-        2 = WRIST
-        3 = FINGER
-        4 = HAND
-        5 = EARLOBE
-        6 = FOOT
-        7:255 = RESERVED
+  setupHeartrateMonitor()
+  This function initializes the heartrate monitor service.
+  hrms.begin() must be called before any characteristics can be set.
+  hrmc.setProperties() defines the way that we will send the data
+  hrmc.setPermission() defines the security access. First parameter is read, second is write.
+  hrmc.setFixedLen() defines how many bytes the characteristic has
+    first byte is metadata
+  second byte is heartrate
+  Now, the characteristic can begin, and once started we can write to it
+  hrmc.write() tells the characteristic to expect 8 bit values and that the PulseSensor is connected
+  The Sensor Location characteristic setup is similar.
+  After is it begun, the bslc.write() sends a byte variable to set the physical location of the PulseSensor
+    0 = OTHER
+    1 = CHEST
+    2 = WRIST
+    3 = FINGER
+    4 = HAND
+    5 = EARLOBE
+    6 = FOOT
+    7:255 = RESERVED
 */
-void setupHeartrateMonitor(void){
+void setupHeartrateMonitor(void) {
   hrms.begin();
   hrmc.setProperties(CHR_PROPS_NOTIFY);
   hrmc.setPermission(SECMODE_OPEN, SECMODE_NO_ACCESS);
-  hrmc.setFixedLen(2);  
+  hrmc.setFixedLen(2);
   hrmc.begin();
-  uint8_t heartRateCharacteristicData[2] = { 0b00000110, 0x40 }; // Set the characteristic to use 8-bit values, with the sensor connected and detected
+  uint8_t heartRateCharacteristicData[2] = {0b00000110, 0x40};  // Set the characteristic to use 8-bit values, with the sensor connected and detected
   hrmc.notify(heartRateCharacteristicData, 2);
   bslc.setProperties(CHR_PROPS_READ);
   bslc.setPermission(SECMODE_OPEN, SECMODE_NO_ACCESS);
   bslc.setFixedLen(1);
   bslc.begin();
-  bslc.write8(3);    // Set the characteristic to 'Finger' (3)
+  bslc.write8(3);  // Set the characteristic to 'Finger' (3)
 }
 
 /*
@@ -244,9 +245,9 @@ void setupHeartrateMonitor(void){
     It gets a reference to the current connection,
     then prints feedback to the serial port
 */
-void connect_callback(uint16_t conn_handle){
+void connect_callback(uint16_t conn_handle) {
   BLEConnection* connection = Bluefruit.Connection(conn_handle);
-  char central_name[32] = { 0 };
+  char central_name[32] = {0};
   connection->getPeerName(central_name, sizeof(central_name));
   Serial.print("Connected to ");
   Serial.println(central_name);
@@ -258,10 +259,10 @@ void connect_callback(uint16_t conn_handle){
     reason is a status code describing the reason for the disconnect
     for example the code 0x13 corresponds to User Terminated Connection.
 */
-void disconnect_callback(uint16_t conn_handle, uint8_t reason){
+void disconnect_callback(uint16_t conn_handle, uint8_t reason) {
   (void) conn_handle;
   (void) reason;
-  Serial.print("Disconnected, reason = 0x"); Serial.println(reason, HEX);
+  Serial.print("Disconnected, reason = 0x");
+  Serial.println(reason, HEX);
   Serial.println("Advertising!");
 }
-

--- a/examples/SoftwareSerialDemo/SoftwareSerialDemo.ino
+++ b/examples/SoftwareSerialDemo/SoftwareSerialDemo.ino
@@ -22,51 +22,51 @@
    https://github.com/WorldFamousElectronics/PulseSensorPlayground/blob/master/resources/PulseSensor%20Playground%20Tools.md
 */
 /*
-   Include the PulseSensor Playground library to get all the good stuff!
-   The PulseSensor Playground library will decide whether to use
-   a hardware timer to get accurate sample readings by checking
-   what target hardware is being used and adjust accordingly.
-   You may see a "warning" come up in red during compilation
-   if a hardware timer is not being used.
+  Include the PulseSensor Playground library to get all the good stuff!
+  The PulseSensor Playground library will decide whether to use
+  a hardware timer to get accurate sample readings by checking
+  what target hardware is being used and adjust accordingly.
+  You may see a "warning" come up in red during compilation
+  if a hardware timer is not being used.
 */
 #include <PulseSensorPlayground.h>
 #include <SoftwareSerial.h>
 
 /*
-   The format of our output.
+  The format of our output.
 
-   Set this to PROCESSING_VISUALIZER if you're going to run
-   the Processing Visualizer Sketch.
-   See https://github.com/WorldFamousElectronics/PulseSensor_Amped_Processing_Visualizer
+  Set this to PROCESSING_VISUALIZER if you're going to run
+  the Processing Visualizer Sketch.
+  See https://github.com/WorldFamousElectronics/PulseSensor_Amped_Processing_Visualizer
 
-   Set this to SERIAL_PLOTTER if you're going to run
-   the Arduino IDE's Serial Plotter.
+  Set this to SERIAL_PLOTTER if you're going to run
+  the Arduino IDE's Serial Plotter.
 */
 const int OUTPUT_TYPE = SERIAL_PLOTTER;
 
 /*
-     PIN_RX = Serial Receive pin (input into Arduino)
-     PIN_TX = Serial Transmit pin (output from Arduino)
+  PIN_RX = Serial Receive pin (input into Arduino)
+  PIN_TX = Serial Transmit pin (output from Arduino)
 
-     In most cases, you'll want to wire the Arduino PIN_RX
-     to the TRANSMIT pin of the external serial device,
-     and the Arduino PIN_TX to the RECEIVE pin of the
-     external device.
+  In most cases, you'll want to wire the Arduino PIN_RX
+  to the TRANSMIT pin of the external serial device,
+  and the Arduino PIN_TX to the RECEIVE pin of the
+  external device.
 */
 const int PIN_RX = 7;
 const int PIN_TX = 8;
 
 /*
-   Pinout:
-     PULSE_INPUT = Analog Input. Connected to the pulse sensor
+  Pinout:
+    PULSE_INPUT = Analog Input. Connected to the pulse sensor
       purple (signal) wire.
-     PULSE_BLINK = digital Output. Connected to an LED (and 1K series resistor)
+    PULSE_BLINK = digital Output. Connected to an LED (and 1K series resistor)
       that will flash on each detected pulse.
-     PULSE_FADE = digital Output. PWM pin onnected to an LED (and 1K series resistor)
+    PULSE_FADE = digital Output. PWM pin onnected to an LED (and 1K series resistor)
       that will smoothly fade with each pulse.
       NOTE: PULSE_FADE must be a pin that supports PWM. Do not use
       pin 9 or 10, because those pins' PWM interferes with the sample timer.
-     THRESHOLD should be set higher than the PulseSensor signal idles
+    THRESHOLD should be set higher than the PulseSensor signal idles
       at when there is nothing touching it. The expected idle value
       should be 512, which is 1/2 of the ADC range. To check the idle value
       open a serial monitor and make note of the PulseSensor signal values
@@ -78,12 +78,12 @@ const int PIN_TX = 8;
 */
 const int PULSE_INPUT = A0;
 const int PULSE_BLINK = LED_BUILTIN;
-const int PULSE_FADE = 5;      // Must be a PWM pin other than 9 or 10.
-const int THRESHOLD = 550;   // Adjust this number to avoid noise when idle
+const int PULSE_FADE = 5;   // Must be a PWM pin other than 9 or 10.
+const int THRESHOLD = 550;  // Adjust this number to avoid noise when idle
 
 /*
-   Our software serial controller.
- */
+  Our software serial controller.
+*/
 SoftwareSerial ourSerial(PIN_RX, PIN_TX);
 
 PulseSensorPlayground pulseSensor;
@@ -104,13 +104,13 @@ void setup() {
 
   if (!pulseSensor.begin()) {
     /*
-     * PulseSensor initialization failed,
-     * likely because our particular Arduino platform interrupts
-     * aren't supported yet.
-     *
-     * If your Sketch hangs here, try changing USE_ARDUINO_INTERRUPTS to false.
-     */
-    for(;;) {
+      PulseSensor initialization failed,
+      likely because our particular Arduino platform interrupts
+      aren't supported yet.
+
+      If your Sketch hangs here, try changing USE_ARDUINO_INTERRUPTS to false.
+    */
+    for (;;) {
       // Flash the led to show things didn't work.
       digitalWrite(PULSE_BLINK, LOW);
       delay(50);
@@ -122,42 +122,42 @@ void setup() {
 
 void loop() {
   /*
-     See if a sample is ready from the PulseSensor.
+    See if a sample is ready from the PulseSensor.
 
-     If USE_HARDWARE_TIMER is true, the PulseSensor Playground
-     will automatically read and process samples from
-     the PulseSensor.
+    If USE_HARDWARE_TIMER is true, the PulseSensor Playground
+    will automatically read and process samples from
+    the PulseSensor.
 
-     If USE_HARDWARE_TIMER is false, the call to sawNewSample()
-     will check to see how much time has passed, then read
-     and process a sample (analog voltage) from the PulseSensor.
-     Call this function often to maintain 500Hz sample rate,
-     that is every 2 milliseconds. Best not to have any delay() 
-     functions in the loop when using a software timer.
+    If USE_HARDWARE_TIMER is false, the call to sawNewSample()
+    will check to see how much time has passed, then read
+    and process a sample (analog voltage) from the PulseSensor.
+    Call this function often to maintain 500Hz sample rate,
+    that is every 2 milliseconds. Best not to have any delay()
+    functions in the loop when using a software timer.
 
-     Check the compatibility of your hardware at this link
-     <url>
-     and delete the unused code portions in your saved copy, if you like.
+    Check the compatibility of your hardware at this link
+    <url>
+    and delete the unused code portions in your saved copy, if you like.
   */
-  if(pulseSensor.UsingHardwareTimer){
+  if (pulseSensor.UsingHardwareTimer) {
     /*
-       Wait a bit.
-       We don't output every sample, because our baud rate
-       won't support that much I/O.
+      Wait a bit.
+      We don't output every sample, because our baud rate
+      won't support that much I/O.
     */
-    delay(20); 
+    delay(20);
     // write the latest sample to Serial.
     pulseSensor.outputSample();
   } else {
-  /*
+    /*
       When using a software timer, we have to check to see if it is time
       to acquire another sample. A call to sawNewSample will do that.
-  */
+    */
     if (pulseSensor.sawNewSample()) {
       /*
-          Every 20 millisectonds, send the latest Sample.
-          We don't print every sample, because our baud rate
-          won't support that much I/O.
+        Every 20 millisectonds, send the latest Sample.
+        We don't print every sample, because our baud rate
+        won't support that much I/O.
       */
       if ((pulseSensor.samplesUntilReport--) == 0) {
         pulseSensor.samplesUntilReport = SAMPLES_PER_SERIAL_SAMPLE;
@@ -169,5 +169,4 @@ void loop() {
   if (pulseSensor.sawStartOfBeat()) {
     pulseSensor.outputBeat();
   }
-
 }

--- a/examples/TwoPulseSensors_On_OneArduino/TwoPulseSensors_On_OneArduino.ino
+++ b/examples/TwoPulseSensors_On_OneArduino/TwoPulseSensors_On_OneArduino.ino
@@ -25,44 +25,44 @@
 */
 
 /*
-   Include the PulseSensor Playground library to get all the good stuff!
-   The PulseSensor Playground library will decide whether to use
-   a hardware timer to get accurate sample readings by checking
-   what target hardware is being used and adjust accordingly.
-   You may see a "warning" come up in red during compilation
-   if a hardware timer is not being used.
+  Include the PulseSensor Playground library to get all the good stuff!
+  The PulseSensor Playground library will decide whether to use
+  a hardware timer to get accurate sample readings by checking
+  what target hardware is being used and adjust accordingly.
+  You may see a "warning" come up in red during compilation
+  if a hardware timer is not being used.
 */
 #include <PulseSensorPlayground.h>
 
 
 /*
-   The format of our output.
+  The format of our output.
 
-   Set this to PROCESSING_VISUALIZER if you're going to run
+  Set this to PROCESSING_VISUALIZER if you're going to run
     the multi-sensor Processing Visualizer Sketch.
     See https://github.com/WorldFamousElectronics/PulseSensorAmped_2_Sensors
 
-   Set this to SERIAL_PLOTTER if you're going to run
+  Set this to SERIAL_PLOTTER if you're going to run
     the Arduino IDE's Serial Plotter.
 */
 const int OUTPUT_TYPE = SERIAL_PLOTTER;
 
 /*
-   Number of PulseSensor devices we're reading from.
+  Number of PulseSensor devices we're reading from.
 */
 const int PULSE_SENSOR_COUNT = 2;
 
 /*
-   Pinout:
-     PULSE_INPUT = Analog Input. Connected to the pulse sensor
+  Pinout:
+    PULSE_INPUT = Analog Input. Connected to the pulse sensor
       purple (signal) wire. Ends with index number.
-     PULSE_BLINK = digital Output. Connected to an LED (and 1K series resistor)
+    PULSE_BLINK = digital Output. Connected to an LED (and 1K series resistor)
       that will flash on each detected pulse. Ends with index number.
-     PULSE_FADE = digital Output. PWM pin onnected to an LED (and 1K series resistor)
+    PULSE_FADE = digital Output. PWM pin onnected to an LED (and 1K series resistor)
       that will smoothly fade with each pulse. Ends with index number.
       NOTE: PULSE_FADE must be a pin that supports PWM. Do not use
       pin 9 or 10, because those pins' PWM interferes with the sample timer. Ends with index number.
-     THRESHOLD should be set higher than the PulseSensor signal idles
+    THRESHOLD should be set higher than the PulseSensor signal idles
       at when there is nothing touching it. The expected idle value
       should be 512, which is 1/2 of the ADC range. To check the idle value
       open a serial monitor and make note of the PulseSensor signal values
@@ -80,32 +80,32 @@ const int PULSE_INPUT1 = A1;
 const int PULSE_BLINK1 = 12;
 const int PULSE_FADE1 = 11;
 
-const int THRESHOLD0 = 550;  
-const int THRESHOLD1 = 550; 
+const int THRESHOLD0 = 550;
+const int THRESHOLD1 = 550;
 
 /*
-   All the PulseSensor Playground functions.
-   We tell it how many PulseSensors we're using.
+  All the PulseSensor Playground functions.
+  We tell it how many PulseSensors we're using.
 */
 PulseSensorPlayground pulseSensor(PULSE_SENSOR_COUNT);
 
 void setup() {
   /*
-     Use 250000 baud because that's what the Processing Sketch expects to read,
-     and because that speed provides about 25 bytes per millisecond,
-     or 50 characters per PulseSensor sample period of 2 milliseconds.
+    Use 250000 baud because that's what the Processing Sketch expects to read,
+    and because that speed provides about 25 bytes per millisecond,
+    or 50 characters per PulseSensor sample period of 2 milliseconds.
 
-     If we used a slower baud rate, we'd likely write bytes faster than
-     they can be transmitted, which would mess up the timing
-     of readSensor() calls, which would make the pulse measurement
-     not work properly.
+    If we used a slower baud rate, we'd likely write bytes faster than
+    they can be transmitted, which would mess up the timing
+    of readSensor() calls, which would make the pulse measurement
+    not work properly.
   */
   Serial.begin(250000);
 
   /*
-     Configure the PulseSensor manager,
-     telling it which PulseSensor (0 or 1)
-     we're configuring.
+    Configure the PulseSensor manager,
+    telling it which PulseSensor (0 or 1)
+    we're configuring.
   */
 
   pulseSensor.analogInput(PULSE_INPUT0, 0);
@@ -153,32 +153,32 @@ void loop() {
      will check to see how much time has passed, then read
      and process a sample (analog voltage) from the PulseSensor.
      Call this function often to maintain 500Hz sample rate,
-     that is every 2 milliseconds. Best not to have any delay() 
+     that is every 2 milliseconds. Best not to have any delay()
      functions in the loop when using a software timer.
 
      Check the compatibility of your hardware at this link
      <url>
      and delete the unused code portions in your saved copy, if you like.
   */
-  if(pulseSensor.UsingHardwareTimer){
+  if (pulseSensor.UsingHardwareTimer) {
     /*
        Wait a bit.
        We don't output every sample, because our baud rate
        won't support that much I/O.
     */
-    delay(20); 
+    delay(20);
     // write the latest sample to Serial.
     pulseSensor.outputSample();
   } else {
-  /*
+    /*
       When using a software timer, we have to check to see if it is time
       to acquire another sample. A call to sawNewSample will do that.
-  */
+    */
     if (pulseSensor.sawNewSample()) {
       /*
-          Every 20 milliseconds, send the latest Sample.
-          We don't print every sample, because our baud rate
-          won't support that much I/O.
+        Every 20 milliseconds, send the latest Sample.
+        We don't print every sample, because our baud rate
+        won't support that much I/O.
       */
       if ((pulseSensor.samplesUntilReport--) == 0) {
         pulseSensor.samplesUntilReport = SAMPLES_PER_SERIAL_SAMPLE;
@@ -187,9 +187,9 @@ void loop() {
     }
   }
   /*
-     If a beat has happened on a given PulseSensor
-     since we last checked, write the per-beat information
-     about that PulseSensor to Serial.
+    If a beat has happened on a given PulseSensor
+    since we last checked, write the per-beat information
+    about that PulseSensor to Serial.
   */
   for (int i = 0; i < PULSE_SENSOR_COUNT; ++i) {
     if (pulseSensor.sawStartOfBeat(i)) {


### PR DESCRIPTION
Hello.
I noticed that some of the examples had tabs and spaces mixed, among other things, so I made a .clang_format file based on the general style on the code and applied on the examples to improve on:
- inconsistent use of tabs and spaces (used spaces everywhere)
- inconsistent indentation
- trailing whitespace and other details

Changes were all whitespace and should not change behavior.