### PR TITLE
Adds 4 XIAO ESP32S3 examples

### DIFF
--- a/examples/PulseSensor_XIAO_ESP32S3_BPM/PulseSensor_XIAO_ESP32S3_BPM.ino
+++ b/examples/PulseSensor_XIAO_ESP32S3_BPM/PulseSensor_XIAO_ESP32S3_BPM.ino
@@ -12,7 +12,7 @@
  *   PulseSensor Power (Red)     - 3.3V
  *   PulseSensor Ground (Black)  - GND
  * 
- * >> https://pulsesensor.com/pages/esp32-getting-started
+ * >> https://pulsesensor.com/pages/pulsesensor_xiao_esp32s3
  *
  * Copyright World Famous Electronics LLC - see LICENSE
  * Contributors:
@@ -27,7 +27,7 @@
 
 #include <PulseSensorPlayground.h>
 
-const int PULSE_PIN = 0;
+const int PULSE_PIN = 1;
 const int LED_PIN = 21;
 
 PulseSensorPlayground pulseSensor;

--- a/examples/PulseSensor_XIAO_ESP32S3_BPM/PulseSensor_XIAO_ESP32S3_BPM.ino
+++ b/examples/PulseSensor_XIAO_ESP32S3_BPM/PulseSensor_XIAO_ESP32S3_BPM.ino
@@ -1,0 +1,54 @@
+/*
+ * PulseSensor_XIAO_ESP32S3_BPM_Monitor.ino
+ * Version: 1.0.0
+ * 
+ * Uses library's built-in averaging for stable BPM.
+ * Displays heart rate in Serial Monitor.
+ * 
+ * Hardware: XIAO ESP32S3, PulseSensor
+ * 
+ * Wiring:
+ *   PulseSensor Signal (Purple) - A0 (GPIO 1)
+ *   PulseSensor Power (Red)     - 3.3V
+ *   PulseSensor Ground (Black)  - GND
+ * 
+ * >> https://pulsesensor.com/pages/esp32-getting-started
+ *
+ * Copyright World Famous Electronics LLC - see LICENSE
+ * Contributors:
+ *   Joel Murphy, https://pulsesensor.com
+ *   Yury Gitman, https://pulsesensor.com
+ *
+ * Licensed under the MIT License, a copy of which
+ * should have been included with this software.
+ *
+ * This software is not intended for medical use.
+ */
+
+#include <PulseSensorPlayground.h>
+
+const int PULSE_PIN = 0;
+const int LED_PIN = 21;
+
+PulseSensorPlayground pulseSensor;
+
+void setup() {
+  Serial.begin(115200);
+  Serial.println("PulseSensor_XIAO_ESP32S3_BPM_Monitor.ino");
+  Serial.println("PulseSensor.com");
+
+  pulseSensor.analogInput(PULSE_PIN);
+  pulseSensor.blinkOnPulse(LED_PIN);
+  pulseSensor.setThreshold(550);
+  pulseSensor.begin();
+}
+
+void loop() {
+  int bpm = pulseSensor.getBeatsPerMinute();
+
+  if (pulseSensor.sawStartOfBeat()) {
+    Serial.print("BPM: ");
+    Serial.println(bpm);
+  }
+  delay(20);
+}

--- a/examples/PulseSensor_XIAO_ESP32S3_OLED/PulseSensor_XIAO_ESP32S3_OLED.ino
+++ b/examples/PulseSensor_XIAO_ESP32S3_OLED/PulseSensor_XIAO_ESP32S3_OLED.ino
@@ -16,7 +16,7 @@
  *   OLED VCC                    - 3.3V
  *   OLED GND                    - GND
  * 
- * >> https://pulsesensor.com/pages/esp32-getting-started
+ * >> https://pulsesensor.com/pages/pulsesensor_xiao_esp32s3
  *
  * Copyright World Famous Electronics LLC - see LICENSE
  * Contributors:
@@ -34,7 +34,7 @@
 #include <Adafruit_GFX.h>
 #include <Adafruit_SH110X.h>
 
-const int PULSE_PIN = 0;
+const int PULSE_PIN = 1;
 const int LED_PIN = 21;
 
 PulseSensorPlayground pulseSensor;
@@ -60,7 +60,7 @@ void setup() {
   Wire.begin(5, 6);
   display.begin(0x3C, true);
   display.setTextColor(SH110X_WHITE);
-  
+
   // Splash screen
   display.clearDisplay();
   display.setTextSize(1);

--- a/examples/PulseSensor_XIAO_ESP32S3_OLED/PulseSensor_XIAO_ESP32S3_OLED.ino
+++ b/examples/PulseSensor_XIAO_ESP32S3_OLED/PulseSensor_XIAO_ESP32S3_OLED.ino
@@ -1,0 +1,131 @@
+/*
+ * PulseSensor_XIAO_ESP32S3_OLED_Lib.ino
+ * Version: 1.0.0
+ * 
+ * OLED display with library-powered beat detection.
+ * Shows waveform and BPM on 1.3" SH1106 OLED.
+ * 
+ * Hardware: XIAO ESP32S3, PulseSensor, 1.3" SH1106 OLED
+ * 
+ * Wiring:
+ *   PulseSensor Signal (Purple) - A0 (GPIO 1)
+ *   PulseSensor Power (Red)     - 3.3V
+ *   PulseSensor Ground (Black)  - GND
+ *   OLED SDA                    - D4 (GPIO 5)
+ *   OLED SCL                    - D5 (GPIO 6)
+ *   OLED VCC                    - 3.3V
+ *   OLED GND                    - GND
+ * 
+ * >> https://pulsesensor.com/pages/esp32-getting-started
+ *
+ * Copyright World Famous Electronics LLC - see LICENSE
+ * Contributors:
+ *   Joel Murphy, https://pulsesensor.com
+ *   Yury Gitman, https://pulsesensor.com
+ *
+ * Licensed under the MIT License, a copy of which
+ * should have been included with this software.
+ *
+ * This software is not intended for medical use.
+ */
+
+#include <PulseSensorPlayground.h>
+#include <Wire.h>
+#include <Adafruit_GFX.h>
+#include <Adafruit_SH110X.h>
+
+const int PULSE_PIN = 0;
+const int LED_PIN = 21;
+
+PulseSensorPlayground pulseSensor;
+Adafruit_SH1106G display(128, 64, &Wire, -1);
+
+// Waveform buffer
+#define WAVE_WIDTH 100
+int waveBuffer[WAVE_WIDTH];
+int waveIndex = 0;
+
+void setup() {
+  Serial.begin(115200);
+  Serial.println("PulseSensor_XIAO_ESP32S3_OLED_Lib.ino");
+  Serial.println("PulseSensor.com");
+
+  // Initialize PulseSensor
+  pulseSensor.analogInput(PULSE_PIN);
+  pulseSensor.blinkOnPulse(LED_PIN);
+  pulseSensor.setThreshold(550);
+  pulseSensor.begin();
+
+  // Initialize OLED
+  Wire.begin(5, 6);
+  display.begin(0x3C, true);
+  display.setTextColor(SH110X_WHITE);
+  
+  // Splash screen
+  display.clearDisplay();
+  display.setTextSize(1);
+  display.setCursor(20, 20);
+  display.println("PulseSensor");
+  display.setCursor(20, 35);
+  display.println("OLED + Library");
+  display.display();
+  delay(2000);
+
+  // Initialize waveform buffer
+  for (int i = 0; i < WAVE_WIDTH; i++) {
+    waveBuffer[i] = 32;
+  }
+}
+
+void loop() {
+  // Get data from library
+  int signal = pulseSensor.getLatestSample();
+  int bpm = pulseSensor.getBeatsPerMinute();
+  bool beat = pulseSensor.sawStartOfBeat();
+
+  // Update waveform buffer
+  int y = map(signal, 0, 4095, 63, 20);
+  y = constrain(y, 20, 63);
+  waveBuffer[waveIndex] = y;
+  waveIndex = (waveIndex + 1) % WAVE_WIDTH;
+
+  // Draw display
+  display.clearDisplay();
+
+  // Header
+  display.setTextSize(1);
+  display.setCursor(0, 0);
+  display.print("BPM: ");
+  if (bpm > 40 && bpm < 200) {
+    display.print(bpm);
+  } else {
+    display.print("--");
+  }
+
+  // Heart icon on beat
+  if (beat) {
+    display.setCursor(60, 0);
+    display.print("*");
+  }
+
+  // Runtime
+  unsigned long secs = millis() / 1000;
+  unsigned long mins = secs / 60;
+  secs = secs % 60;
+  display.setCursor(90, 0);
+  if (mins < 10) display.print("0");
+  display.print(mins);
+  display.print(":");
+  if (secs < 10) display.print("0");
+  display.print(secs);
+
+  // Draw waveform
+  for (int i = 0; i < WAVE_WIDTH - 1; i++) {
+    int idx = (waveIndex + i) % WAVE_WIDTH;
+    int idxNext = (waveIndex + i + 1) % WAVE_WIDTH;
+    display.drawLine(14 + i, waveBuffer[idx], 14 + i + 1, waveBuffer[idxNext], SH110X_WHITE);
+  }
+
+  display.display();
+  delay(20);
+}

--- a/examples/PulseSensor_XIAO_ESP32S3_WiFi/PulseSensor_XIAO_ESP32S3_WiFi.ino
+++ b/examples/PulseSensor_XIAO_ESP32S3_WiFi/PulseSensor_XIAO_ESP32S3_WiFi.ino
@@ -12,7 +12,7 @@
  *   PulseSensor Power (Red)     - 3.3V
  *   PulseSensor Ground (Black)  - GND
  * 
- * >> https://pulsesensor.com/pages/esp32-getting-started
+ * >> https://pulsesensor.com/pages/pulsesensor_xiao_esp32s3
  *
  * Copyright World Famous Electronics LLC - see LICENSE
  * Contributors:
@@ -31,7 +31,7 @@
 #include <WebSocketsServer.h>
 
 const char* WIFI_NAME = "PulseSensor.com";
-const int PULSE_PIN = 0;
+const int PULSE_PIN = 1;
 const int LED_PIN = 21;
 
 PulseSensorPlayground pulseSensor;
@@ -117,7 +117,7 @@ const char DASHBOARD_HTML[] PROGMEM = R"rawliteral(
     canvas.height = 180;
     let data = [];
     const maxPts = 150;
-    
+
     const ws = new WebSocket('ws://' + location.hostname + ':81');
     ws.onopen = () => {
       document.getElementById('status').textContent = 'Connected';
@@ -132,12 +132,12 @@ const char DASHBOARD_HTML[] PROGMEM = R"rawliteral(
       const sig = parseInt(p[0]);
       const bpm = parseInt(p[1]);
       const beat = p[2] === '1';
-      
+
       const valid = bpm >= 40 && bpm <= 200;
       const bpmEl = document.getElementById('bpm');
       const heartEl = document.getElementById('heart');
       const hintEl = document.getElementById('hint');
-      
+
       if (valid) {
         bpmEl.textContent = bpm;
         bpmEl.className = 'bpm-value normal';
@@ -150,12 +150,12 @@ const char DASHBOARD_HTML[] PROGMEM = R"rawliteral(
         hintEl.textContent = 'Place finger on sensor';
       }
       if (beat && valid) setTimeout(() => heartEl.classList.remove('beat'), 150);
-      
+
       data.push(sig);
       if (data.length > maxPts) data.shift();
       drawWave();
     };
-    
+
     function drawWave() {
       ctx.fillStyle = '#1a1a1a';
       ctx.fillRect(0, 0, canvas.width, canvas.height);

--- a/examples/PulseSensor_XIAO_ESP32S3_WiFi/PulseSensor_XIAO_ESP32S3_WiFi.ino
+++ b/examples/PulseSensor_XIAO_ESP32S3_WiFi/PulseSensor_XIAO_ESP32S3_WiFi.ino
@@ -1,0 +1,220 @@
+/*
+ * PulseSensor_XIAO_ESP32S3_WiFi_Lib.ino
+ * Version: 1.0.0
+ * 
+ * WiFi Dashboard with library-powered beat detection.
+ * Connect to "PulseSensor.com" WiFi - Open 192.168.4.1
+ * 
+ * Hardware: XIAO ESP32S3, PulseSensor
+ * 
+ * Wiring:
+ *   PulseSensor Signal (Purple) - A0 (GPIO 1)
+ *   PulseSensor Power (Red)     - 3.3V
+ *   PulseSensor Ground (Black)  - GND
+ * 
+ * >> https://pulsesensor.com/pages/esp32-getting-started
+ *
+ * Copyright World Famous Electronics LLC - see LICENSE
+ * Contributors:
+ *   Joel Murphy, https://pulsesensor.com
+ *   Yury Gitman, https://pulsesensor.com
+ *
+ * Licensed under the MIT License, a copy of which
+ * should have been included with this software.
+ *
+ * This software is not intended for medical use.
+ */
+
+#include <PulseSensorPlayground.h>
+#include <WiFi.h>
+#include <WebServer.h>
+#include <WebSocketsServer.h>
+
+const char* WIFI_NAME = "PulseSensor.com";
+const int PULSE_PIN = 0;
+const int LED_PIN = 21;
+
+PulseSensorPlayground pulseSensor;
+WebServer server(80);
+WebSocketsServer webSocket(81);
+int clientCount = 0;
+
+const char DASHBOARD_HTML[] PROGMEM = R"rawliteral(
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>PulseSensor Dashboard</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #111;
+      color: white;
+      min-height: 100vh;
+      padding: 20px;
+    }
+    .container { max-width: 500px; margin: 0 auto; }
+    h1 { text-align: center; margin-bottom: 20px; font-size: 1.4em; font-weight: 500; }
+    .card {
+      background: #222;
+      border-radius: 15px;
+      padding: 20px;
+      margin-bottom: 15px;
+    }
+    .bpm-display {
+      text-align: center;
+      padding: 25px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 20px;
+    }
+    .bpm-value { font-size: 4em; font-weight: bold; }
+    .bpm-label { font-size: 1.1em; opacity: 0.7; }
+    .bpm-hint { font-size: 0.85em; opacity: 0.5; margin-top: 5px; }
+    .heart { font-size: 3em; transition: transform 0.1s; }
+    .heart.beat { transform: scale(1.3); }
+    .normal { color: #ff4444; }
+    .invalid { color: #444; }
+    canvas {
+      width: 100%;
+      height: 180px;
+      background: #1a1a1a;
+      border-radius: 10px;
+    }
+    .label { font-size: 0.8em; opacity: 0.6; margin-bottom: 8px; }
+    .status { text-align: center; padding: 10px; font-size: 0.85em; opacity: 0.6; }
+    .connected { color: #4a4; }
+    .disconnected { color: #a44; }
+    .footer { text-align: center; margin-top: 20px; font-size: 0.75em; opacity: 0.4; }
+    .footer a { color: #ff4444; text-decoration: none; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>PulseSensor Dashboard</h1>
+    <div class="card bpm-display">
+      <span class="heart normal" id="heart">&#9829;</span>
+      <div>
+        <div class="bpm-value normal" id="bpm">--</div>
+        <div class="bpm-label">BPM</div>
+        <div class="bpm-hint" id="hint">Place finger on sensor</div>
+      </div>
+    </div>
+    <div class="card">
+      <div class="label">Pulse Waveform</div>
+      <canvas id="wave"></canvas>
+    </div>
+    <div class="status" id="status">Connecting...</div>
+    <div class="footer">Powered by <a href="https://pulsesensor.com">PulseSensor.com</a></div>
+  </div>
+  <script>
+    const canvas = document.getElementById('wave');
+    const ctx = canvas.getContext('2d');
+    canvas.width = canvas.offsetWidth;
+    canvas.height = 180;
+    let data = [];
+    const maxPts = 150;
+    
+    const ws = new WebSocket('ws://' + location.hostname + ':81');
+    ws.onopen = () => {
+      document.getElementById('status').textContent = 'Connected';
+      document.getElementById('status').className = 'status connected';
+    };
+    ws.onclose = () => {
+      document.getElementById('status').textContent = 'Disconnected';
+      document.getElementById('status').className = 'status disconnected';
+    };
+    ws.onmessage = (e) => {
+      const p = e.data.split(',');
+      const sig = parseInt(p[0]);
+      const bpm = parseInt(p[1]);
+      const beat = p[2] === '1';
+      
+      const valid = bpm >= 40 && bpm <= 200;
+      const bpmEl = document.getElementById('bpm');
+      const heartEl = document.getElementById('heart');
+      const hintEl = document.getElementById('hint');
+      
+      if (valid) {
+        bpmEl.textContent = bpm;
+        bpmEl.className = 'bpm-value normal';
+        heartEl.className = 'heart normal' + (beat ? ' beat' : '');
+        hintEl.textContent = 'Reading pulse...';
+      } else {
+        bpmEl.textContent = '--';
+        bpmEl.className = 'bpm-value invalid';
+        heartEl.className = 'heart invalid';
+        hintEl.textContent = 'Place finger on sensor';
+      }
+      if (beat && valid) setTimeout(() => heartEl.classList.remove('beat'), 150);
+      
+      data.push(sig);
+      if (data.length > maxPts) data.shift();
+      drawWave();
+    };
+    
+    function drawWave() {
+      ctx.fillStyle = '#1a1a1a';
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      if (data.length < 2) return;
+      const min = Math.min(...data), max = Math.max(...data), range = max - min || 1;
+      ctx.strokeStyle = '#ff4444';
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      for (let i = 0; i < data.length; i++) {
+        const x = (i / maxPts) * canvas.width;
+        const y = canvas.height - ((data[i] - min) / range) * (canvas.height - 20) - 10;
+        i === 0 ? ctx.moveTo(x, y) : ctx.lineTo(x, y);
+      }
+      ctx.stroke();
+    }
+  </script>
+</body>
+</html>
+)rawliteral";
+
+void onWebSocketEvent(uint8_t num, WStype_t type, uint8_t *payload, size_t length) {
+  if (type == WStype_CONNECTED) clientCount++;
+  else if (type == WStype_DISCONNECTED) clientCount = max(0, clientCount - 1);
+}
+
+void setup() {
+  Serial.begin(115200);
+  Serial.println("PulseSensor_XIAO_ESP32S3_WiFi_Lib.ino");
+  Serial.println("PulseSensor.com");
+
+  // Initialize PulseSensor
+  pulseSensor.analogInput(PULSE_PIN);
+  pulseSensor.blinkOnPulse(LED_PIN);
+  pulseSensor.setThreshold(550);
+  pulseSensor.begin();
+
+  // Start WiFi
+  WiFi.softAP(WIFI_NAME);
+  server.on("/", []() { server.send_P(200, "text/html", DASHBOARD_HTML); });
+  server.begin();
+  webSocket.begin();
+  webSocket.onEvent(onWebSocketEvent);
+
+  Serial.println("WiFi Started: PulseSensor.com");
+  Serial.println("Open: 192.168.4.1");
+}
+
+void loop() {
+  server.handleClient();
+  webSocket.loop();
+
+  // Get data from library
+  int signal = pulseSensor.getLatestSample();
+  int bpm = pulseSensor.getBeatsPerMinute();
+  bool beat = pulseSensor.sawStartOfBeat();
+
+  // Send to connected browsers
+  String data = String(signal) + "," + String(bpm) + "," + (beat ? "1" : "0");
+  webSocket.broadcastTXT(data);
+
+  delay(10);
+}

--- a/examples/PulseSensor_XIAO_ESP32S3_WiFi_OLED/PulseSensor_XIAO_ESP32S3_WiFi_OLED.ino
+++ b/examples/PulseSensor_XIAO_ESP32S3_WiFi_OLED/PulseSensor_XIAO_ESP32S3_WiFi_OLED.ino
@@ -17,7 +17,7 @@
  *   OLED VCC                    - 3.3V
  *   OLED GND                    - GND
  * 
- * >> https://pulsesensor.com/pages/esp32-getting-started
+ * >> https://pulsesensor.com/pages/pulsesensor_xiao_esp32s3
  *
  * Copyright World Famous Electronics LLC - see LICENSE
  * Contributors:
@@ -157,7 +157,6 @@ void updateDisplay() {
   display.clearDisplay();
   display.setTextSize(1);
 
-  // Runtime (top right)
   unsigned long secs = millis() / 1000;
   unsigned long mins = secs / 60;
   secs = secs % 60;

--- a/examples/PulseSensor_XIAO_ESP32S3_WiFi_OLED/PulseSensor_XIAO_ESP32S3_WiFi_OLED.ino
+++ b/examples/PulseSensor_XIAO_ESP32S3_WiFi_OLED/PulseSensor_XIAO_ESP32S3_WiFi_OLED.ino
@@ -1,0 +1,275 @@
+/*
+ * PulseSensor_XIAO_ESP32S3_WiFi_OLED.ino
+ * Version: 1.0.0
+ * 
+ * WiFi Dashboard + OLED + Library-powered beat detection.
+ * Connect to "PulseSensor.com" WiFi - Open 192.168.4.1
+ * Watch your pulse on OLED AND phone simultaneously!
+ * 
+ * Hardware: XIAO ESP32S3, PulseSensor, 1.3" SH1106 OLED
+ * 
+ * Wiring:
+ *   PulseSensor Signal (Purple) - A0 (GPIO 1)
+ *   PulseSensor Power (Red)     - 3.3V
+ *   PulseSensor Ground (Black)  - GND
+ *   OLED SDA                    - D4 (GPIO 5)
+ *   OLED SCL                    - D5 (GPIO 6)
+ *   OLED VCC                    - 3.3V
+ *   OLED GND                    - GND
+ * 
+ * >> https://pulsesensor.com/pages/esp32-getting-started
+ *
+ * Copyright World Famous Electronics LLC - see LICENSE
+ * Contributors:
+ *   Joel Murphy, https://pulsesensor.com
+ *   Yury Gitman, https://pulsesensor.com
+ *
+ * Licensed under the MIT License, a copy of which
+ * should have been included with this software.
+ *
+ * This software is not intended for medical use.
+ */
+
+#include <WiFi.h>
+#include <WebServer.h>
+#include <WebSocketsServer.h>
+#include <Wire.h>
+#include <Adafruit_GFX.h>
+#include <Adafruit_SH110X.h>
+#define USE_ARDUINO_INTERRUPTS false
+#include <PulseSensorPlayground.h>
+
+const char *WIFI_NAME = "PulseSensor.com";
+#define PULSE_PIN 1
+#define SDA_PIN 5
+#define SCL_PIN 6
+#define THRESHOLD 550
+#define SCREEN_WIDTH 128
+#define SCREEN_HEIGHT 64
+
+WebServer server(80);
+WebSocketsServer webSocket(81);
+Adafruit_SH1106G display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, -1);
+PulseSensorPlayground pulseSensor;
+
+int clientCount = 0;
+int BPM = 0;
+bool beatDetected = false;
+unsigned long lastBeatTime = 0;
+
+#define WAVE_WIDTH 50
+int waveBuffer[WAVE_WIDTH];
+int waveIndex = 0;
+
+static const unsigned char PROGMEM heartSmall[] = {
+    0b01101100, 0b11111110, 0b11111110, 0b01111100,
+    0b00111000, 0b00010000, 0b00000000};
+
+static const unsigned char PROGMEM heartBig[] = {
+    0b01101100, 0b11111110, 0b11111110, 0b11111110,
+    0b01111100, 0b00111000, 0b00010000};
+
+const char DASHBOARD_HTML[] PROGMEM = R"rawliteral(
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>PulseSensor (Lib)</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, sans-serif; background: #111; color: white; min-height: 100vh; padding: 20px; }
+    .container { max-width: 500px; margin: 0 auto; }
+    h1 { text-align: center; margin-bottom: 20px; font-size: 1.4em; }
+    .card { background: #222; border-radius: 15px; padding: 20px; margin-bottom: 15px; }
+    .bpm-display { text-align: center; padding: 25px; display: flex; align-items: center; justify-content: center; gap: 20px; }
+    .bpm-value { font-size: 4em; font-weight: bold; }
+    .bpm-label { font-size: 1.1em; opacity: 0.7; }
+    .bpm-hint { font-size: 0.85em; opacity: 0.5; margin-top: 5px; }
+    .heart { font-size: 3em; transition: transform 0.1s; }
+    .heart.beat { transform: scale(1.3); }
+    .normal { color: #ff4444; }
+    .invalid { color: #444; }
+    canvas { width: 100%; height: 180px; background: #1a1a1a; border-radius: 10px; }
+    .label { font-size: 0.8em; opacity: 0.6; margin-bottom: 8px; }
+    .raw-value { text-align: center; font-size: 0.85em; opacity: 0.5; margin-top: 10px; }
+    .status { text-align: center; padding: 10px; font-size: 0.85em; opacity: 0.6; }
+    .connected { color: #4a4; }
+    .disconnected { color: #a44; }
+    .footer { text-align: center; margin-top: 20px; font-size: 0.75em; opacity: 0.4; }
+    .footer a { color: #ff4444; text-decoration: none; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>PulseSensor (Library)</h1>
+    <div class="card bpm-display">
+      <span class="heart normal" id="heart">&#9829;</span>
+      <div>
+        <div class="bpm-value normal" id="bpm">--</div>
+        <div class="bpm-label">BPM</div>
+        <div class="bpm-hint" id="hint">Place finger on sensor</div>
+      </div>
+    </div>
+    <div class="card">
+      <div class="label">Pulse Waveform</div>
+      <canvas id="wave"></canvas>
+      <div class="raw-value">Signal: <span id="raw">--</span></div>
+    </div>
+    <div class="status" id="status">Connecting...</div>
+    <div class="footer"><a href="https://pulsesensor.com">pulsesensor.com</a></div>
+  </div>
+  <script>
+    const wave = document.getElementById('wave'), waveCtx = wave.getContext('2d');
+    wave.width = wave.offsetWidth; wave.height = 180;
+    let data = [], maxPts = 150, valid = false, bpm = 0;
+    const ws = new WebSocket('ws://' + location.hostname + ':81');
+    ws.onopen = () => { document.getElementById('status').textContent = 'Connected'; document.getElementById('status').className = 'status connected'; };
+    ws.onclose = () => { document.getElementById('status').textContent = 'Disconnected'; document.getElementById('status').className = 'status disconnected'; };
+    ws.onmessage = (e) => {
+      const p = e.data.split(','), sig = parseInt(p[0]); bpm = parseInt(p[1]); const beat = p[2] === '1';
+      valid = bpm >= 40 && bpm <= 200;
+      document.getElementById('raw').textContent = sig;
+      const bpmEl = document.getElementById('bpm'), heartEl = document.getElementById('heart'), hintEl = document.getElementById('hint');
+      if (valid) { bpmEl.textContent = bpm; bpmEl.className = 'bpm-value normal'; heartEl.className = 'heart normal' + (beat ? ' beat' : ''); hintEl.textContent = 'Reading...'; }
+      else { bpmEl.textContent = '--'; bpmEl.className = 'bpm-value invalid'; heartEl.className = 'heart invalid'; hintEl.textContent = 'Place finger on sensor'; }
+      if (beat && valid) setTimeout(() => heartEl.classList.remove('beat'), 150);
+      data.push(sig); if (data.length > maxPts) data.shift();
+      waveCtx.fillStyle = '#1a1a1a'; waveCtx.fillRect(0, 0, wave.width, wave.height);
+      if (data.length > 1) {
+        const min = Math.min(...data), max = Math.max(...data), range = max - min || 1;
+        waveCtx.strokeStyle = valid ? '#ff4444' : '#444'; waveCtx.lineWidth = 2; waveCtx.beginPath();
+        for (let i = 0; i < data.length; i++) { const x = (i / maxPts) * wave.width, y = wave.height - ((data[i] - min) / range) * (wave.height - 20) - 10; i === 0 ? waveCtx.moveTo(x, y) : waveCtx.lineTo(x, y); }
+        waveCtx.stroke();
+      }
+    };
+  </script>
+</body>
+</html>
+)rawliteral";
+
+void onWebSocketEvent(uint8_t num, WStype_t type, uint8_t *payload, size_t length) {
+  if (type == WStype_CONNECTED) clientCount++;
+  else if (type == WStype_DISCONNECTED) clientCount = max(0, clientCount - 1);
+}
+
+void updateDisplay() {
+  display.clearDisplay();
+  display.setTextSize(1);
+
+  // Runtime (top right)
+  unsigned long secs = millis() / 1000;
+  unsigned long mins = secs / 60;
+  secs = secs % 60;
+  display.setCursor(90, 0);
+  if (mins < 10) display.print("0");
+  display.print(mins);
+  display.print(":");
+  if (secs < 10) display.print("0");
+  display.print(secs);
+
+  display.setCursor(0, 0);
+  display.print("PulseSensor.com");
+
+  display.setCursor(0, 12);
+  display.print("Open: 192.168.4.1");
+
+  display.setCursor(0, 24);
+  display.print("Clients: ");
+  display.print(clientCount);
+
+  display.setCursor(0, 36);
+  display.print("BPM: ");
+  bool validBPM = BPM >= 40 && BPM <= 200 && millis() - lastBeatTime < 3000;
+  if (validBPM) display.print(BPM);
+  else display.print("--");
+
+  bool recentBeat = millis() - lastBeatTime < 150;
+  if (recentBeat) display.drawBitmap(50, 35, heartBig, 8, 7, SH110X_WHITE);
+  else display.drawBitmap(50, 36, heartSmall, 8, 7, SH110X_WHITE);
+
+  for (int i = 0; i < WAVE_WIDTH - 1; i++) {
+    int idx = (waveIndex + i) % WAVE_WIDTH;
+    int idxNext = (waveIndex + i + 1) % WAVE_WIDTH;
+    display.drawLine(64 + i, 52 + waveBuffer[idx], 64 + i + 1, 52 + waveBuffer[idxNext], SH110X_WHITE);
+  }
+
+  display.display();
+}
+
+void setup() {
+  Serial.begin(115200);
+  Serial.println("PulseSensor_XIAO_ESP32S3_WiFi_OLED.ino");
+  Serial.println("PulseSensor.com");
+
+  Wire.begin(SDA_PIN, SCL_PIN);
+  if (!display.begin(0x3C, true)) {
+    Serial.println("OLED not found!");
+    while (1) delay(100);
+  }
+
+  display.clearDisplay();
+  display.setTextColor(SH110X_WHITE);
+  display.setCursor(15, 15);
+  display.println("XIAO ESP32S3 Lib");
+  display.setCursor(20, 30);
+  display.println("PulseSensor.com");
+  display.setCursor(30, 45);
+  display.println("(Library)");
+  display.display();
+  delay(2000);
+
+  pulseSensor.analogInput(PULSE_PIN);
+  pulseSensor.setThreshold(THRESHOLD);
+  pulseSensor.begin();
+
+  WiFi.softAP(WIFI_NAME);
+
+  server.on("/", []() { server.send_P(200, "text/html", DASHBOARD_HTML); });
+  server.begin();
+
+  webSocket.begin();
+  webSocket.onEvent(onWebSocketEvent);
+
+  analogReadResolution(12);
+
+  for (int i = 0; i < WAVE_WIDTH; i++) waveBuffer[i] = 4;
+
+  Serial.println("=================================");
+  Serial.println("  PulseSensor_XIAO_ESP32S3_WiFi_OLED.ino");
+  Serial.println("  PulseSensor.com");
+  Serial.print("  WiFi: "); Serial.println(WIFI_NAME);
+  Serial.println("  Open: 192.168.4.1");
+  Serial.println("=================================");
+}
+
+void loop() {
+  server.handleClient();
+  webSocket.loop();
+
+  int sensorValue = pulseSensor.getLatestSample();
+
+  beatDetected = false;
+  if (pulseSensor.sawStartOfBeat()) {
+    beatDetected = true;
+    lastBeatTime = millis();
+    BPM = pulseSensor.getBeatsPerMinute();
+  }
+
+  static int sensorHigh = 0, sensorLow = 4095;
+  if (sensorValue > sensorHigh) sensorHigh = sensorValue;
+  if (sensorValue < sensorLow) sensorLow = sensorValue;
+
+  int waveY = map(sensorValue, sensorLow, sensorHigh, 8, 0);
+  waveY = constrain(waveY, 0, 8);
+  waveBuffer[waveIndex] = waveY;
+  waveIndex = (waveIndex + 1) % WAVE_WIDTH;
+
+  String data = String(sensorValue) + "," + String(BPM) + "," +
+                (beatDetected ? "1" : "0") + "," + String(clientCount);
+  webSocket.broadcastTXT(data);
+
+  updateDisplay();
+
+  delay(10);
+}


### PR DESCRIPTION
Adds 4 new examples for XIAO ESP32S3:
- BPM Monitor
- OLED Display
- WiFi Dashboard  
- WiFi + OLED combo

Tutorial: https://pulsesensor.com/pages/pulsesensor_xiao_esp32s3