### PR TITLE
[codex] Link WebSerial and CYD related projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,9 +167,9 @@ We put together a [HANDY GUIDE](https://github.com/WorldFamousElectronics/PulseS
 
 Some PulseSensor projects are better kept outside the Arduino Library Manager package because they need browser features, display setup, or extra dependencies.
 
-- [PulseSensor and Webserial](https://pulsesensor.com/pages/pulsesensor-and-webserial)
+- [PulseSensor and WebSerial](https://pulsesensor.com/pages/pulsesensor-and-webserial)
 - [PulseSensor on CYD](https://pulsesensor.com/pages/cyd)
-- [Related project notes](https://github.com/WorldFamousElectronics/PulseSensorPlayground/blob/master/resources/RelatedProjects.md)
+- [Related project notes](resources/RelatedProjects.md)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,16 @@ We put together a [HANDY GUIDE](https://github.com/WorldFamousElectronics/PulseS
 
 ---
 
+### Related Projects
+
+Some PulseSensor projects are better kept outside the Arduino Library Manager package because they need browser features, display setup, or extra dependencies.
+
+- [PulseSensor and Webserial](https://pulsesensor.com/pages/pulsesensor-and-webserial)
+- [PulseSensor on CYD](https://pulsesensor.com/pages/cyd)
+- [Related project notes](https://github.com/WorldFamousElectronics/PulseSensorPlayground/blob/master/resources/RelatedProjects.md)
+
+---
+
 ### Troubleshooting Your Signal:
 
  <b><details><summary><code> Ugh, Where's the Beat ? </code>😵</summary></b>

--- a/resources/RelatedProjects.md
+++ b/resources/RelatedProjects.md
@@ -6,7 +6,7 @@ Keeping them linked here gives users a path from the core library to richer brow
 
 ## PulseSensor WebSerial
 
-- Tutorial: [PulseSensor and Webserial](https://pulsesensor.com/pages/pulsesensor-and-webserial)
+- Tutorial: [PulseSensor and WebSerial](https://pulsesensor.com/pages/pulsesensor-and-webserial)
 - Development repo: [yury-g/webserial](https://github.com/yury-g/webserial)
 - Local library resource: [webserial-explainer](webserial-explainer/index.html)
 
@@ -20,7 +20,7 @@ WebSerial lets Chrome, Edge, or Brave read USB serial data directly from an Ardu
 
 The CYD project targets ESP32-2432S028 display boards and demonstrates how Playground readings can drive an embedded display: waveform, BPM, IBI, pulse amplitude, beat state, and threshold behavior.
 
-## Why These Are Linked Instead Of Bundled
+## Why These Are Linked Instead of Bundled
 
 The Arduino Library Manager package should stay focused on examples that compile directly from Arduino IDE with predictable dependencies.
 

--- a/resources/RelatedProjects.md
+++ b/resources/RelatedProjects.md
@@ -1,0 +1,27 @@
+# Related PulseSensor Projects
+
+These projects use PulseSensor Playground but are not bundled as Arduino Library Manager examples.
+
+Keeping them linked here gives users a path from the core library to richer browser and ESP32 display demos without making the installed Arduino library package larger or harder to maintain.
+
+## PulseSensor WebSerial
+
+- Tutorial: [PulseSensor and Webserial](https://pulsesensor.com/pages/pulsesensor-and-webserial)
+- Development repo: [yury-g/webserial](https://github.com/yury-g/webserial)
+- Local library resource: [webserial-explainer](webserial-explainer/index.html)
+
+WebSerial lets Chrome, Edge, or Brave read USB serial data directly from an Arduino or ESP32. It is useful for quick waveform/BPM testing because users do not need Processing or a desktop application.
+
+## PulseSensor on CYD
+
+- Tutorial: [PulseSensor on CYD](https://pulsesensor.com/pages/cyd)
+- Official source repo: [WorldFamousElectronics/PulseSensor_CYD](https://github.com/WorldFamousElectronics/PulseSensor_CYD)
+- Development repo: [yury-g/CYD-Two-PulseSensor](https://github.com/yury-g/CYD-Two-PulseSensor)
+
+The CYD project targets ESP32-2432S028 display boards and demonstrates how Playground readings can drive an embedded display: waveform, BPM, IBI, pulse amplitude, beat state, and threshold behavior.
+
+## Why These Are Linked Instead Of Bundled
+
+The Arduino Library Manager package should stay focused on examples that compile directly from Arduino IDE with predictable dependencies.
+
+These related projects are richer applications. They may need browser features, display configuration, board-specific pin mapping, or additional libraries. Linking them keeps the installed Playground library lean while still making the project path discoverable.


### PR DESCRIPTION
## Purpose

This draft PR links the PulseSensor WebSerial and CYD projects from the Playground repo without bundling those richer applications into the Arduino Library Manager package.

## What changed

- Adds `resources/RelatedProjects.md` with links to:
  - PulseSensor WebSerial tutorial and `yury-g/webserial`
  - PulseSensor on CYD tutorial
  - `WorldFamousElectronics/PulseSensor_CYD`
  - `yury-g/CYD-Two-PulseSensor`
- Adds a short README pointer under Developer Resources.
- Uses a relative README link so the new notes resolve correctly while this PR is being reviewed.
- Normalizes `WebSerial` capitalization in the added docs.

## Why

These projects are useful next steps for Playground users, but they are browser/display applications rather than simple Arduino Library Manager examples. Linking them keeps the installed library package lean while making the public project path easier to discover.

## Links verified

- https://pulsesensor.com/pages/pulsesensor-and-webserial
- https://pulsesensor.com/pages/cyd
- https://github.com/WorldFamousElectronics/PulseSensor_CYD
- https://github.com/yury-g/CYD-Two-PulseSensor
- https://github.com/yury-g/webserial
