### PR TITLE
Refresh PulseSensor buying routes and Education & Bulk link

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,12 @@ This Playground is a collection of code for the most popular uses of PulseSensor
 
 ---
 
-## Buy Verified "PulseSensor.com"  
- <b><a href="https://github.com/WorldFamousElectronics/PulseSensorPlayground/wiki/Buy-%22Verified-PulseSensor.com%22"> Where to buy Verified Sensors 💰 </a>  </b>
+## Buy PulseSensor
+
+- **United States:** [Buy the PulseSensor kit on Amazon](https://www.amazon.com/dp/B01CPP4QM0).
+- **International:** [Adafruit carries the PulseSensor kit](https://www.adafruit.com/product/1093) and offers international shipping. Check delivery availability for your destination at checkout.
+- **More buying options:** [PulseSensor buying guide](https://github.com/WorldFamousElectronics/PulseSensorPlayground/wiki/Buy-%22Verified-PulseSensor.com%22).
+
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This Playground is a collection of code for the most popular uses of PulseSensor
 
 - **United States:** [Buy the PulseSensor kit on Amazon](https://www.amazon.com/dp/B01CPP4QM0).
 - **International:** Buy from [SparkFun](https://www.sparkfun.com/pulse-sensor.html) or [Adafruit](https://www.adafruit.com/product/1093).
-- **Schools, labs & bulk orders:** [Request ordering options](https://pulsesensor.com/pages/school-bulk-orders).
+- **100+ pieces or classroom purchases:** [Request a bulk quote](https://pulsesensor.com/pages/school-bulk-orders). 50-piece minimum, in increments of 25.
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This Playground is a collection of code for the most popular uses of PulseSensor
 
 - **United States:** [Buy the PulseSensor kit on Amazon](https://www.amazon.com/dp/B01CPP4QM0).
 - **International:** Buy from [SparkFun](https://www.sparkfun.com/pulse-sensor.html) or [Adafruit](https://www.adafruit.com/product/1093).
-- **100+ pieces or classroom purchases:** [Request a bulk quote](https://pulsesensor.com/pages/school-bulk-orders). 50-piece minimum, in increments of 25.
+- **Education & Bulk:** [Request a bulk quote](https://pulsesensor.com/pages/school-bulk-orders). 50-piece minimum, in increments of 25.
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This Playground is a collection of code for the most popular uses of PulseSensor
 ## Buy PulseSensor
 
 - **United States:** [Buy the PulseSensor kit on Amazon](https://www.amazon.com/dp/B01CPP4QM0).
-- **International:** [Adafruit carries the PulseSensor kit](https://www.adafruit.com/product/1093) and offers international shipping. Check delivery availability for your destination at checkout.
+- **International:** Buy from [Adafruit](https://www.adafruit.com/product/1093) or [SparkFun](https://www.sparkfun.com/pulse-sensor.html). Check shipping to your country and the listed kit contents with the seller.
 - **More buying options:** [PulseSensor buying guide](https://github.com/WorldFamousElectronics/PulseSensorPlayground/wiki/Buy-%22Verified-PulseSensor.com%22).
 
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ This Playground is a collection of code for the most popular uses of PulseSensor
 ## Buy PulseSensor
 
 - **United States:** [Buy the PulseSensor kit on Amazon](https://www.amazon.com/dp/B01CPP4QM0).
-- **International:** Buy from [Adafruit](https://www.adafruit.com/product/1093) or [SparkFun](https://www.sparkfun.com/pulse-sensor.html). Check shipping to your country and the listed kit contents with the seller.
-- **More buying options:** [PulseSensor buying guide](https://github.com/WorldFamousElectronics/PulseSensorPlayground/wiki/Buy-%22Verified-PulseSensor.com%22).
+- **International:** Buy from [SparkFun](https://www.sparkfun.com/pulse-sensor.html) or [Adafruit](https://www.adafruit.com/product/1093).
+- **Schools, labs & bulk orders:** [Request ordering options](https://pulsesensor.com/pages/school-bulk-orders).
 
 
 ---


### PR DESCRIPTION
Refresh the buying section with three clear routes: the U.S. Amazon kit listing, equally prominent SparkFun and Adafruit international links, and the live Education & Bulk inquiry page.

Bulk requests start at 50 kits in increments of 25. The form prefills 100 and states the minimum before contact details. No seller-content caveats or extra verification tasks are imposed on buyers.

Validation: README-only diff and whitespace checks; live Shopify page and form delivery verified. No library or example code changes.
